### PR TITLE
Keep track of return value from original widget (#135)

### DIFF
--- a/src/widgets.zsh
+++ b/src/widgets.zsh
@@ -13,8 +13,11 @@ _zsh_autosuggest_clear() {
 
 # Modify the buffer and get a new suggestion
 _zsh_autosuggest_modify() {
+	local -i retval
+
 	# Original widget modifies the buffer
 	_zsh_autosuggest_invoke_original_widget $@
+	retval=$?
 
 	# Get a new suggestion if the buffer is not empty after modification
 	local suggestion
@@ -28,6 +31,8 @@ _zsh_autosuggest_modify() {
 	else
 		unset POSTDISPLAY
 	fi
+
+	return $retval
 }
 
 # Accept the entire suggestion
@@ -70,6 +75,8 @@ _zsh_autosuggest_execute() {
 
 # Partially accept the suggestion
 _zsh_autosuggest_partial_accept() {
+	local -i retval
+
 	# Save the contents of the buffer so we can restore later if needed
 	local original_buffer="$BUFFER"
 
@@ -78,6 +85,7 @@ _zsh_autosuggest_partial_accept() {
 
 	# Original widget moves the cursor
 	_zsh_autosuggest_invoke_original_widget $@
+	retval=$?
 
 	# If we've moved past the end of the original buffer
 	if [ $CURSOR -gt $#original_buffer ]; then
@@ -90,13 +98,22 @@ _zsh_autosuggest_partial_accept() {
 		# Restore the original buffer
 		BUFFER="$original_buffer"
 	fi
+
+	return $retval
 }
 
 for action in clear modify accept partial_accept execute; do
 	eval "_zsh_autosuggest_widget_$action() {
+		local -i retval
+
 		_zsh_autosuggest_highlight_reset
+
 		_zsh_autosuggest_$action \$@
+		retval=\$?
+
 		_zsh_autosuggest_highlight_apply
+
+		return \$retval
 	}"
 done
 

--- a/test/bind_test.zsh
+++ b/test/bind_test.zsh
@@ -1,0 +1,45 @@
+#!/usr/bin/env zsh
+
+source "${0:a:h}/test_helper.zsh"
+
+oneTimeSetUp() {
+	source_autosuggestions
+}
+
+testInvokeOriginalWidgetDefined() {
+	stub_and_eval \
+		zle \
+		'return 1'
+
+	_zsh_autosuggest_invoke_original_widget 'self-insert'
+
+	assertEquals \
+		'1' \
+		"$?"
+
+	assertTrue \
+		'zle was not invoked' \
+		'stub_called zle'
+
+	restore zle
+}
+
+testInvokeOriginalWidgetUndefined() {
+	stub_and_eval \
+		zle \
+		'return 1'
+
+	_zsh_autosuggest_invoke_original_widget 'some-undefined-widget'
+
+	assertEquals \
+		'0' \
+		"$?"
+
+	assertFalse \
+		'zle was invoked' \
+		'stub_called zle'
+
+	restore zle
+}
+
+run_tests "$0"

--- a/test/widgets/accept_test.zsh
+++ b/test/widgets/accept_test.zsh
@@ -115,6 +115,19 @@ testViCursorNotAtEnd() {
 		"$POSTDISPLAY"
 }
 
+testRetval() {
+	stub_and_eval \
+		_zsh_autosuggest_invoke_original_widget \
+		'return 1'
+
+	_zsh_autosuggest_widget_accept 'original-widget'
+
+	assertEquals \
+		'Did not return correct value from original widget' \
+		'1' \
+		"$?"
+}
+
 testWidget() {
 	stub _zsh_autosuggest_highlight_reset
 	stub _zsh_autosuggest_accept

--- a/test/widgets/clear_test.zsh
+++ b/test/widgets/clear_test.zsh
@@ -31,6 +31,19 @@ testClear() {
 		"$POSTDISPLAY"
 }
 
+testRetval() {
+	stub_and_eval \
+		_zsh_autosuggest_invoke_original_widget \
+		'return 1'
+
+	_zsh_autosuggest_widget_clear 'original-widget'
+
+	assertEquals \
+		'Did not return correct value from original widget' \
+		'1' \
+		"$?"
+}
+
 testWidget() {
 	stub _zsh_autosuggest_highlight_reset
 	stub _zsh_autosuggest_clear

--- a/test/widgets/execute_test.zsh
+++ b/test/widgets/execute_test.zsh
@@ -1,0 +1,26 @@
+#!/usr/bin/env zsh
+
+source "${0:a:h}/../test_helper.zsh"
+
+oneTimeSetUp() {
+	source_autosuggestions
+}
+
+tearDown() {
+	restore _zsh_autosuggest_invoke_original_widget
+}
+
+testRetval() {
+	stub_and_eval \
+		_zsh_autosuggest_invoke_original_widget \
+		'return 1'
+
+	_zsh_autosuggest_widget_execute 'original-widget'
+
+	assertEquals \
+		'Did not return correct value from original widget' \
+		'1' \
+		"$?"
+}
+
+run_tests "$0"

--- a/test/widgets/modify_test.zsh
+++ b/test/widgets/modify_test.zsh
@@ -40,7 +40,19 @@ testModify() {
 		'POSTDISPLAY does not contain suggestion' \
 		'cho hello' \
 		"$POSTDISPLAY"
+}
 
+testRetval() {
+	stub_and_eval \
+		_zsh_autosuggest_invoke_original_widget \
+		'return 1'
+
+	_zsh_autosuggest_widget_modify 'original-widget'
+
+	assertEquals \
+		'Did not return correct value from original widget' \
+		'1' \
+		"$?"
 }
 
 run_tests "$0"

--- a/test/widgets/partial_accept_test.zsh
+++ b/test/widgets/partial_accept_test.zsh
@@ -68,4 +68,17 @@ testCursorStaysInBuffer() {
 		"$POSTDISPLAY"
 }
 
+testRetval() {
+	stub_and_eval \
+		_zsh_autosuggest_invoke_original_widget \
+		'return 1'
+
+	_zsh_autosuggest_widget_partial_accept 'original-widget'
+
+	assertEquals \
+		'Did not return correct value from original widget' \
+		'1' \
+		"$?"
+}
+
 run_tests "$0"

--- a/zsh-autosuggestions.zsh
+++ b/zsh-autosuggestions.zsh
@@ -230,8 +230,11 @@ _zsh_autosuggest_clear() {
 
 # Modify the buffer and get a new suggestion
 _zsh_autosuggest_modify() {
+	local -i retval
+
 	# Original widget modifies the buffer
 	_zsh_autosuggest_invoke_original_widget $@
+	retval=$?
 
 	# Get a new suggestion if the buffer is not empty after modification
 	local suggestion
@@ -245,6 +248,8 @@ _zsh_autosuggest_modify() {
 	else
 		unset POSTDISPLAY
 	fi
+
+	return $retval
 }
 
 # Accept the entire suggestion
@@ -287,6 +292,8 @@ _zsh_autosuggest_execute() {
 
 # Partially accept the suggestion
 _zsh_autosuggest_partial_accept() {
+	local -i retval
+
 	# Save the contents of the buffer so we can restore later if needed
 	local original_buffer="$BUFFER"
 
@@ -295,6 +302,7 @@ _zsh_autosuggest_partial_accept() {
 
 	# Original widget moves the cursor
 	_zsh_autosuggest_invoke_original_widget $@
+	retval=$?
 
 	# If we've moved past the end of the original buffer
 	if [ $CURSOR -gt $#original_buffer ]; then
@@ -307,13 +315,22 @@ _zsh_autosuggest_partial_accept() {
 		# Restore the original buffer
 		BUFFER="$original_buffer"
 	fi
+
+	return $retval
 }
 
 for action in clear modify accept partial_accept execute; do
 	eval "_zsh_autosuggest_widget_$action() {
+		local -i retval
+
 		_zsh_autosuggest_highlight_reset
+
 		_zsh_autosuggest_$action \$@
+		retval=\$?
+
 		_zsh_autosuggest_highlight_apply
+
+		return \$retval
 	}"
 done
 


### PR DESCRIPTION
Should fix issue #135, compatibility with `zaw`.