### PR TITLE
Adjust plugin.zsh file to run on zsh 5.1 in mSYS2.

### DIFF
--- a/zsh-autosuggestions.plugin.zsh
+++ b/zsh-autosuggestions.plugin.zsh
@@ -1,1 +1,1 @@
-zsh-autosuggestions.zsh
+source $(dirname $0)/zsh-autosuggestions.zsh


### PR DESCRIPTION
A sole filename caused "command not found" errors while loading with zplug or oh-no-zsh on zsh 5.1.1 inside mSYS2 (Windows).
Sourcing the main file seems to work fine.