### PR TITLE
add # symbol to escape characters

### DIFF
--- a/zsh-autosuggestions.zsh
+++ b/zsh-autosuggestions.zsh
@@ -339,7 +339,7 @@ _zsh_autosuggest_escape_command() {
 	setopt localoptions EXTENDED_GLOB
 
 	# Escape special chars in the string (requires EXTENDED_GLOB)
-	echo -E "${1//(#m)[\\()\[\]|*?]/\\$MATCH}"
+	echo -E "${1//(#m)[\\()\[\]|*?#]/\\$MATCH}"
 }
 
 # Get the previously executed command


### PR DESCRIPTION
Otherwise, autosuggestions failing at strings with `#`.