### PR TITLE
Adjust plugin.zsh file to run on zsh 5.1 in mSYS2.

### DIFF
--- a/zsh-autosuggestions.plugin.zsh
+++ b/zsh-autosuggestions.plugin.zsh
@@ -1,1 +1,1 @@
-zsh-autosuggestions.zsh
+source ${0:A:h}/zsh-autosuggestions.zsh


### PR DESCRIPTION
I have fixed the missing brackets in plugin.zsh file. Now it works flawlessly under msys2 on Windows.
I have closed the other pull request as, being frank, I didn't know how to add a somthing from a different branch to it.