### PR TITLE
Document caveats of match_prev_cmd strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Set `ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE` to configure the style that the suggestion
 Set `ZSH_AUTOSUGGEST_STRATEGY` to choose the strategy for generating suggestions. There are currently two to choose from:
 
 - `default`: Chooses the most recent match.
-- `match_prev_cmd`: Chooses the most recent match whose preceding history item matches the most recently executed command ([more info](src/strategies/match_prev_cmd.zsh)).
+- `match_prev_cmd`: Chooses the most recent match whose preceding history item matches the most recently executed command ([more info](src/strategies/match_prev_cmd.zsh)).  Note that this strategy won't work as expected with ZSH options that don't preserve the history order such as `HIST_IGNORE_ALL_DUPS` or `HIST_EXPIRE_DUPS_FIRST`.
 
 
 ### Widget Mapping

--- a/src/strategies/match_prev_cmd.zsh
+++ b/src/strategies/match_prev_cmd.zsh
@@ -16,6 +16,9 @@
 # will be 'ls foo' rather than 'ls bar' because your most recently
 # executed command (pwd) was previously followed by 'ls foo'.
 #
+# Note that this strategy won't work as expected with ZSH options that don't
+# preserve the history order such as `HIST_IGNORE_ALL_DUPS` or
+# `HIST_EXPIRE_DUPS_FIRST`.
 
 _zsh_autosuggest_strategy_match_prev_cmd() {
 	local prefix="$(_zsh_autosuggest_escape_command "$1")"


### PR DESCRIPTION
This strategy relies on the history being exactly in the order in which
commands have been entered.  Therefore, options like suppressing
duplicates or expiring duplicates first will lead to unexpected
suggestions.