### PR TITLE
Disable autosuggest if buffer is too large

### DIFF
--- a/src/widgets.zsh
+++ b/src/widgets.zsh
@@ -24,7 +24,7 @@ _zsh_autosuggest_modify() {
 
 	# Get a new suggestion if the buffer is not empty after modification
 	local suggestion
-	if [ $#BUFFER -gt 0 ]; then
+	if [ $#BUFFER -gt 0 -a $#BUFFER -lt 20 ]; then
 		suggestion="$(_zsh_autosuggest_suggestion "$BUFFER")"
 	fi
 

--- a/zsh-autosuggestions.zsh
+++ b/zsh-autosuggestions.zsh
@@ -242,7 +242,7 @@ _zsh_autosuggest_modify() {
 
 	# Get a new suggestion if the buffer is not empty after modification
 	local suggestion
-	if [ $#BUFFER -gt 0 ]; then
+	if [ $#BUFFER -gt 0 -a $#BUFFER -lt 20 ]; then
 		suggestion="$(_zsh_autosuggest_suggestion "$BUFFER")"
 	fi
 


### PR DESCRIPTION
This is a workaround when copying large amount of texts in a terminal, i.e. with mouse-button-2.
The idea is to disable autosuggestion when buffer is too large. This avoids that the autosuggest function is called too many times (it's called once per character), slowing it down the paste.
I hardcoded the max buffer length to 20 chars. Possibly, it could be a configurable value instead.