### PR TITLE
Disable autosuggest if buffer is too large

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,12 @@ Widgets not in any of these lists will update the suggestion when invoked.
 **Note:** A widget shouldn't belong to more than one of the above arrays.
 
 
+### Disabling suggestion for large buffers
+
+Set `ZSH_AUTOSUGGEST_BUFFER_MAX_SIZE` to an integer value to disable autosuggestion for large buffers. The default is unset, which means that autosuggestion will be tried for any buffer size. Recommended value is 20.
+This can be useful when pasting large amount of text in the terminal, to avoid triggering autosuggestion for too long strings.
+
+
 ### Key Bindings
 
 This plugin provides three widgets that you can use with `bindkey`:

--- a/src/config.zsh
+++ b/src/config.zsh
@@ -47,3 +47,6 @@ ZSH_AUTOSUGGEST_PARTIAL_ACCEPT_WIDGETS=(
 	vi-forward-blank-word
 	vi-forward-blank-word-end
 )
+
+# Max size of buffer to trigger autosuggestion. Leave undefined for no upper bound.
+ZSH_AUTOSUGGEST_BUFFER_MAX_SIZE=

--- a/src/widgets.zsh
+++ b/src/widgets.zsh
@@ -25,7 +25,9 @@ _zsh_autosuggest_modify() {
 	# Get a new suggestion if the buffer is not empty after modification
 	local suggestion
 	if [ $#BUFFER -gt 0 ]; then
-		suggestion="$(_zsh_autosuggest_suggestion "$BUFFER")"
+		if [ -z "$ZSH_BUFFER_MAX_SIZE" -o $#BUFFER -lt "$ZSH_BUFFER_MAX_SIZE" ]; then
+			suggestion="$(_zsh_autosuggest_suggestion "$BUFFER")"
+		fi
 	fi
 
 	# Add the suggestion to the POSTDISPLAY

--- a/src/widgets.zsh
+++ b/src/widgets.zsh
@@ -25,7 +25,7 @@ _zsh_autosuggest_modify() {
 	# Get a new suggestion if the buffer is not empty after modification
 	local suggestion
 	if [ $#BUFFER -gt 0 ]; then
-		if [ -z "$ZSH_BUFFER_MAX_SIZE" -o $#BUFFER -lt "$ZSH_BUFFER_MAX_SIZE" ]; then
+		if [ -z "$ZSH_AUTOSUGGEST_BUFFER_MAX_SIZE" -o $#BUFFER -lt "$ZSH_AUTOSUGGEST_BUFFER_MAX_SIZE" ]; then
 			suggestion="$(_zsh_autosuggest_suggestion "$BUFFER")"
 		fi
 	fi

--- a/test/widgets/modify_test.zsh
+++ b/test/widgets/modify_test.zsh
@@ -9,6 +9,7 @@ oneTimeSetUp() {
 setUp() {
 	BUFFER=''
 	POSTDISPLAY=''
+	ZSH_BUFFER_MAX_SIZE=''
 }
 
 tearDown() {
@@ -39,6 +40,35 @@ testModify() {
 	assertEquals \
 		'POSTDISPLAY does not contain suggestion' \
 		'cho hello' \
+		"$POSTDISPLAY"
+}
+
+testModifyBufferTooLarge() {
+
+	ZSH_BUFFER_MAX_SIZE='20'
+
+	stub_and_eval \
+		_zsh_autosuggest_invoke_original_widget \
+		'BUFFER+="012345678901234567890"'
+
+	stub_and_echo \
+		_zsh_autosuggest_suggestion \
+		'012345678901234567890123456789'
+
+	_zsh_autosuggest_modify 'original-widget'
+
+	assertTrue \
+		'original widget not invoked' \
+		'stub_called _zsh_autosuggest_invoke_original_widget'
+
+	assertEquals \
+		'BUFFER was not modified' \
+		'012345678901234567890' \
+		"$BUFFER"
+
+	assertEquals \
+		'POSTDISPLAY does not contain suggestion' \
+		'' \
 		"$POSTDISPLAY"
 }
 

--- a/test/widgets/modify_test.zsh
+++ b/test/widgets/modify_test.zsh
@@ -9,7 +9,7 @@ oneTimeSetUp() {
 setUp() {
 	BUFFER=''
 	POSTDISPLAY=''
-	ZSH_BUFFER_MAX_SIZE=''
+	ZSH_AUTOSUGGEST_BUFFER_MAX_SIZE=''
 }
 
 tearDown() {
@@ -45,7 +45,7 @@ testModify() {
 
 testModifyBufferTooLarge() {
 
-	ZSH_BUFFER_MAX_SIZE='20'
+	ZSH_AUTOSUGGEST_BUFFER_MAX_SIZE='20'
 
 	stub_and_eval \
 		_zsh_autosuggest_invoke_original_widget \

--- a/zsh-autosuggestions.zsh
+++ b/zsh-autosuggestions.zsh
@@ -243,7 +243,9 @@ _zsh_autosuggest_modify() {
 	# Get a new suggestion if the buffer is not empty after modification
 	local suggestion
 	if [ $#BUFFER -gt 0 ]; then
-		suggestion="$(_zsh_autosuggest_suggestion "$BUFFER")"
+		if [ -z "$ZSH_BUFFER_MAX_SIZE" -o $#BUFFER -lt "$ZSH_BUFFER_MAX_SIZE" ]; then
+			suggestion="$(_zsh_autosuggest_suggestion "$BUFFER")"
+		fi
 	fi
 
 	# Add the suggestion to the POSTDISPLAY

--- a/zsh-autosuggestions.zsh
+++ b/zsh-autosuggestions.zsh
@@ -74,6 +74,9 @@ ZSH_AUTOSUGGEST_PARTIAL_ACCEPT_WIDGETS=(
 	vi-forward-blank-word-end
 )
 
+# Max size of buffer to trigger autosuggestion. Leave undefined for no upper bound.
+ZSH_AUTOSUGGEST_BUFFER_MAX_SIZE=
+
 #--------------------------------------------------------------------#
 # Handle Deprecated Variables/Widgets                                #
 #--------------------------------------------------------------------#
@@ -243,7 +246,7 @@ _zsh_autosuggest_modify() {
 	# Get a new suggestion if the buffer is not empty after modification
 	local suggestion
 	if [ $#BUFFER -gt 0 ]; then
-		if [ -z "$ZSH_BUFFER_MAX_SIZE" -o $#BUFFER -lt "$ZSH_BUFFER_MAX_SIZE" ]; then
+		if [ -z "$ZSH_AUTOSUGGEST_BUFFER_MAX_SIZE" -o $#BUFFER -lt "$ZSH_AUTOSUGGEST_BUFFER_MAX_SIZE" ]; then
 			suggestion="$(_zsh_autosuggest_suggestion "$BUFFER")"
 		fi
 	fi


### PR DESCRIPTION
Make buffer max size configurable, defaulted to infinity ($ZSH_BUFFER_MAX_SIZE).