### PR TITLE
Don't bind any zle-* methods

### DIFF
--- a/src/bind.zsh
+++ b/src/bind.zsh
@@ -53,7 +53,7 @@ _zsh_autosuggest_bind_widgets() {
 	ignore_widgets=(
 		.\*
 		_\*
-		zle-line-\*
+		zle-\*
 		autosuggest-\*
 		$ZSH_AUTOSUGGEST_ORIGINAL_WIDGET_PREFIX\*
 		$ZSH_AUTOSUGGEST_IGNORE_WIDGETS

--- a/zsh-autosuggestions.zsh
+++ b/zsh-autosuggestions.zsh
@@ -177,7 +177,7 @@ _zsh_autosuggest_bind_widgets() {
 	ignore_widgets=(
 		.\*
 		_\*
-		zle-line-\*
+		zle-\*
 		autosuggest-\*
 		$ZSH_AUTOSUGGEST_ORIGINAL_WIDGET_PREFIX\*
 		$ZSH_AUTOSUGGEST_IGNORE_WIDGETS


### PR DESCRIPTION
It seems like all the zle-* methods are special and shouldn't be
monkeyed with.

Specifically `zle-isearch-update` and friends. Binding that widget
caused `history-incremental-pattern-search` to stop working.

Fixes zsh-users/zsh-syntax-highlighting#387