### PR TITLE
Add 'emacs-forward-word'

### DIFF
--- a/src/config.zsh
+++ b/src/config.zsh
@@ -42,6 +42,7 @@ ZSH_AUTOSUGGEST_EXECUTE_WIDGETS=(
 # Widgets that accept the suggestion as far as the cursor moves
 ZSH_AUTOSUGGEST_PARTIAL_ACCEPT_WIDGETS=(
 	forward-word
+	emacs-forward-word
 	vi-forward-word
 	vi-forward-word-end
 	vi-forward-blank-word

--- a/zsh-autosuggestions.zsh
+++ b/zsh-autosuggestions.zsh
@@ -78,6 +78,7 @@ ZSH_AUTOSUGGEST_EXECUTE_WIDGETS=(
 # Widgets that accept the suggestion as far as the cursor moves
 ZSH_AUTOSUGGEST_PARTIAL_ACCEPT_WIDGETS=(
 	forward-word
+	emacs-forward-word
 	vi-forward-word
 	vi-forward-word-end
 	vi-forward-blank-word


### PR DESCRIPTION
This commit adds the 'emacs-forward-word' widget to the list of partial accept widgets.