### PR TITLE
Added installation instructions for AUR, Homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,39 @@ It suggests commands as you type, based on command history.
 
 3. Start a new terminal session.
 
+### Arch Linux via the AUR
+1. Install the [`zsh-autosuggestions`](https://aur.archlinux.org/packages/zsh-autosuggestions/) or the [`zsh-autosuggestions-git`](https://aur.archlinux.org/packages/zsh-autosuggestions-git/) packages from the [AUR](https://wiki.archlinux.org/index.php/Arch_User_Repository).
+
+    ```sh
+    pacuar -S zsh-autosuggestions
+    ```
+    or
+    ```
+    pacaur -S zsh-autosuggestions-git
+    ```
+
+2. Add the following to your `.zshrc`:
+
+    ```sh
+    source /usr/share/zsh/plugins/zsh-autosuggestions/zsh-autosuggestions.zsh
+    ```
+
+3. Start a new terminal session.
+
+### macOS via Homebrew
+1. Install the `zsh-autosuggestions` package using [Homebrew](https://brew.sh/).
+
+    ```sh
+    brew install zsh-autosuggestions
+    ```
+
+2. Add the following to your `.zshrc`:
+
+    ```sh
+    source /usr/local/share/zsh-autosuggestions/zsh-autosuggestions.zsh
+    ```
+
+3. Start a new terminal session.
 
 ## Usage
 


### PR DESCRIPTION
I added instructions for how to install `zsh-autosuggestions` via the AUR (for Arch Linux) and Homebrew (for macOS).