### PR TITLE
escape pattern-matching chars on $prefix for match_prev_cmd strategy

### DIFF
--- a/src/strategies/match_prev_cmd.zsh
+++ b/src/strategies/match_prev_cmd.zsh
@@ -26,7 +26,7 @@ _zsh_autosuggest_strategy_match_prev_cmd() {
 	# Get all history event numbers that correspond to history
 	# entries that match pattern $prefix*
 	local history_match_keys
-	history_match_keys=(${(k)history[(R)$prefix*]})
+	history_match_keys=(${(k)history[(R)${(b)prefix}*]})
 
 	# By default we use the first history number (most recent history entry)
 	local histkey="${history_match_keys[1]}"

--- a/zsh-autosuggestions.zsh
+++ b/zsh-autosuggestions.zsh
@@ -533,7 +533,7 @@ _zsh_autosuggest_strategy_match_prev_cmd() {
 	# Get all history event numbers that correspond to history
 	# entries that match pattern $prefix*
 	local history_match_keys
-	history_match_keys=(${(k)history[(R)$prefix*]})
+	history_match_keys=(${(k)history[(R)${(b)prefix}*]})
 
 	# By default we use the first history number (most recent history entry)
 	local histkey="${history_match_keys[1]}"


### PR DESCRIPTION
this should fix issues #247 and #258 where pattern-matching characters in the buffer are not escaped before matching against history when using the match_prev_cmd strategy.