### PR TITLE
git:// -> https://

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ It suggests commands as you type, based on command history.
 1. Clone this repository somewhere on your machine. This guide will assume `~/.zsh/zsh-autosuggestions`.
 
     ```sh
-    git clone git://github.com/zsh-users/zsh-autosuggestions ~/.zsh/zsh-autosuggestions
+    git clone https://github.com/zsh-users/zsh-autosuggestions ~/.zsh/zsh-autosuggestions
     ```
 
 2. Add the following to your `.zshrc`:


### PR DESCRIPTION
`git://` didn't work for me but `https://` did.