### PR TITLE
Don't break kill ring rotation

### DIFF
--- a/zsh-autosuggestions.zsh
+++ b/zsh-autosuggestions.zsh
@@ -93,6 +93,7 @@ ZSH_AUTOSUGGEST_IGNORE_WIDGETS=(
 	set-local-history
 	which-command
 	yank
+	yank-pop
 )
 
 # Max size of buffer to trigger autosuggestion. Leave undefined for no upper bound.


### PR DESCRIPTION
Without this patch, using yank-pop after yank is not repeatable and puts the cursor in the wrong position (one character to the left of the expected position).