### PR TITLE
Avoid ringing bell when accepting suggestions

### DIFF
--- a/src/bind.zsh
+++ b/src/bind.zsh
@@ -106,7 +106,7 @@ _zsh_autosuggest_bind_widgets() {
 # Given the name of an original widget and args, invoke it, if it exists
 _zsh_autosuggest_invoke_original_widget() {
 	# Do nothing unless called with at least one arg
-	(( $# )) || return
+	(( $# )) || return 0
 
 	local original_widget_name="$1"
 

--- a/zsh-autosuggestions.zsh
+++ b/zsh-autosuggestions.zsh
@@ -238,7 +238,7 @@ _zsh_autosuggest_bind_widgets() {
 # Given the name of an original widget and args, invoke it, if it exists
 _zsh_autosuggest_invoke_original_widget() {
 	# Do nothing unless called with at least one arg
-	(( $# )) || return
+	(( $# )) || return 0
 
 	local original_widget_name="$1"
 


### PR DESCRIPTION
Fixes #228

Quoting my comment on the ticket:

>This happens because `_zsh_autosuggest_invoke_original_widget()` returns `1` when provided no 'original widget' (which it won't be in this case), and the `_zsh_autosuggest_widget_*()` functions pass this status on. Per the ZLE widget documentation:
>
>>A non-zero return status causes the shell to beep when the widget exits, unless the BEEP options was unset or the widget was called via the zle command.
>
>I'm not super familiar with the code base yet but i don't see any reason why `_zsh_autosuggest_invoke_original_widget()` needs to return `1` here — it's not an error condition and it doesn't seem to provide any other useful information to the caller. I've only tested briefly but i haven't seen any issues so far with just having it always return `0` when there are no arguments.

I'm not sure how to add tests for this, but the change doesn't seem to break the existing ones, anyway.