### PR TITLE
Don't fetch suggestions after [up,down]-line-or-beginning-search

### DIFF
--- a/spec/integrations/async_line_or_beginning_spec.rb
+++ b/spec/integrations/async_line_or_beginning_spec.rb
@@ -1,0 +1,27 @@
+describe 'using up-line-or-beginning-search when async is enabled' do
+  let(:options) { ["ZSH_AUTOSUGGEST_USE_ASYNC="] }
+  let(:before_sourcing) do
+    -> do
+      session.
+        run_command('autoload -U up-line-or-beginning-search').
+        run_command('zle -N up-line-or-beginning-search').
+        send_string('bindkey "').
+        send_keys('C-v').send_keys('up').
+        send_string('" up-line-or-beginning-search').
+        send_keys('enter')
+    end
+  end
+
+  it 'should show previous history entries' do
+    with_history(
+      'echo foo',
+      'echo bar',
+      'echo baz'
+    ) do
+      session.clear_screen
+      3.times { session.send_keys('up') }
+      wait_for { session.content }.to eq("echo foo")
+    end
+  end
+end
+

--- a/src/config.zsh
+++ b/src/config.zsh
@@ -21,6 +21,8 @@ ZSH_AUTOSUGGEST_CLEAR_WIDGETS=(
 	history-beginning-search-backward
 	history-substring-search-up
 	history-substring-search-down
+	up-line-or-beginning-search
+	down-line-or-beginning-search
 	up-line-or-history
 	down-line-or-history
 	accept-line

--- a/zsh-autosuggestions.zsh
+++ b/zsh-autosuggestions.zsh
@@ -57,6 +57,8 @@ ZSH_AUTOSUGGEST_CLEAR_WIDGETS=(
 	history-beginning-search-backward
 	history-substring-search-up
 	history-substring-search-down
+	up-line-or-beginning-search
+	down-line-or-beginning-search
 	up-line-or-history
 	down-line-or-history
 	accept-line


### PR DESCRIPTION
Should fix #241 and #227.

These widgets rely on `$LASTWIDGET` being set to restore the cursor position. When asynchronous suggestions are enabled, and the widget triggers a suggestion to be fetched, `autosuggest-suggest` will be called and $LASTWIDGET will be set to it.