### PR TITLE
make Oh my zsh install works without ZSH_CUSTOM defined

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Requirements: Zsh v4.3.11 or later
 1. Clone this repository into `$ZSH_CUSTOM/plugins` (by default `~/.oh-my-zsh/custom/plugins`)
 
     ```sh
-    git clone https://github.com/zsh-users/zsh-autosuggestions $ZSH_CUSTOM/plugins/zsh-autosuggestions
+    git clone https://github.com/zsh-users/zsh-autosuggestions ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/zsh-autosuggestions
     ```
 
 2. Add the plugin to the list of plugins for Oh My Zsh to load:


### PR DESCRIPTION
Handle installation for oh my zsh without ZSH_CUSTOM defined the same way it is done in [zsh-syntax-highlighting](https://github.com/zsh-users/zsh-syntax-highlighting/blob/master/INSTALL.md#oh-my-zsh).