### PR TITLE
update arch linux installation instructions (now available via pacman)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,16 +46,18 @@ Requirements: Zsh v4.3.11 or later
 
 3. Start a new terminal session.
 
-### Arch Linux via the AUR
-1. Install the [`zsh-autosuggestions`](https://aur.archlinux.org/packages/zsh-autosuggestions/) or the [`zsh-autosuggestions-git`](https://aur.archlinux.org/packages/zsh-autosuggestions-git/) packages from the [AUR](https://wiki.archlinux.org/index.php/Arch_User_Repository).
+### Arch Linux
+
+1. Install
+   [`zsh-autosuggestions`](https://www.archlinux.org/packages/community/any/zsh-autosuggestions/)
+   from the `community` repository.
 
     ```sh
-    pacaur -S zsh-autosuggestions
+    pacman -S zsh-autosuggestions
     ```
-    or
-    ```
-    pacaur -S zsh-autosuggestions-git
-    ```
+    or, to use a package based on the `master` branch, install
+    [`zsh-autosuggestions-git`](https://aur.archlinux.org/packages/zsh-autosuggestions-git/)
+    from the [AUR](https://wiki.archlinux.org/index.php/Arch_User_Repository).
 
 2. Add the following to your `.zshrc`:
 


### PR DESCRIPTION
closes #328

---

The `zsh-autosuggestions` package is no longer available in the AUR, but via the community repository. This patch refactors the Arch Linux installation instructions to reflect this. Additionally, the instructions for `zsh-autosuggestions-git` were refactored to remove the example using `pacaur`, and instead simply instructing users of the package name and the fact that it is available. The anchors to the AUR package page and the Arch Linux wiki entry for the AUR have been retained.