### PR TITLE
Feature: Allow cycling throw history in the autocompletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ This plugin provides a few widgets that you can use with `bindkey`:
 5. `autosuggest-disable`: Disables suggestions.
 6. `autosuggest-enable`: Re-enables suggestions.
 7. `autosuggest-toggle`: Toggles between enabled/disabled suggestions.
+8. `autosuggest-next`: Suggests the next older entry from history.
+9. `autosuggest-previous`: Suggests the next newer entry from history.
 
 For example, this would bind <kbd>ctrl</kbd> + <kbd>space</kbd> to accept the current suggestion.
 

--- a/spec/options/strategy_spec.rb
+++ b/spec/options/strategy_spec.rb
@@ -1,7 +1,7 @@
 describe 'a suggestion for a given prefix' do
   let(:history_strategy) { '_zsh_autosuggest_strategy_history() { suggestion="history" }' }
-  let(:foobar_strategy) { '_zsh_autosuggest_strategy_foobar() { [[ "foobar baz" = $1* ]] && suggestion="foobar baz" }' }
-  let(:foobaz_strategy) { '_zsh_autosuggest_strategy_foobaz() { [[ "foobaz bar" = $1* ]] && suggestion="foobaz bar" }' }
+  let(:foobar_strategy) { '_zsh_autosuggest_strategy_foobar() { [[ "foobar baz" = $2* ]] && suggestion="foobar baz" }' }
+  let(:foobaz_strategy) { '_zsh_autosuggest_strategy_foobaz() { [[ "foobaz bar" = $2* ]] && suggestion="foobaz bar" }' }
 
   let(:options) { [ history_strategy ] }
 

--- a/spec/widgets/next_spec.rb
+++ b/spec/widgets/next_spec.rb
@@ -1,0 +1,63 @@
+describe 'the `autosuggest-next` widget' do
+  context 'when suggestions are disabled' do
+    before do
+      session.
+        run_command('bindkey ^B autosuggest-disable').
+        run_command('bindkey ^K autosuggest-next').
+        send_keys('C-b')
+    end
+    it 'will fetch and display a suggestion' do
+      with_history('echo hello', 'echo world', 'echo joe') do
+        session.send_string('echo h')
+        sleep 1
+        expect(session.content).to eq('echo h')
+        session.send_keys('C-k')
+        wait_for { session.content }.to eq('echo hello')
+        session.send_string('e')
+        wait_for { session.content }.to eq('echo hello')
+      end
+    end
+  end
+
+  context 'invoked on a populated history' do
+    before do
+      session.
+        run_command('bindkey ^K autosuggest-next')
+    end
+    it 'will cycle, fetch, and display a suggestion' do
+      with_history('echo hello', 'echo world', 'echo joe') do
+        session.send_string('echo')
+        sleep 1
+        expect(session.content).to eq('echo joe')
+        session.send_keys('C-k')
+        wait_for { session.content }.to eq('echo world')
+        session.send_keys('C-k')
+        wait_for { session.content }.to eq('echo hello')
+        session.send_keys('C-k')
+        wait_for { session.content }.to eq('echo hello')
+      end
+    end
+  end
+
+  context 'when async mode is enabled' do
+    let(:options) { ['ZSH_AUTOSUGGEST_USE_ASYNC=true', 'ZSH_AUTOSUGGEST_STRATEGY=history'] }
+
+    before do
+      session.
+        run_command('bindkey ^K autosuggest-next')
+    end
+    it 'will cycle, fetch, and display a suggestion' do
+      with_history('echo hello', 'echo world', 'echo joe') do
+        session.send_string('echo')
+        sleep 1
+        expect(session.content).to eq('echo joe')
+        session.send_keys('C-k')
+        wait_for { session.content }.to eq('echo world')
+        session.send_keys('C-k')
+        wait_for { session.content }.to eq('echo hello')
+        session.send_keys('C-k')
+        wait_for { session.content }.to eq('echo hello')
+      end
+    end
+  end
+end

--- a/spec/widgets/previous_spec.rb
+++ b/spec/widgets/previous_spec.rb
@@ -1,0 +1,77 @@
+describe 'the `autosuggest-previous` widget' do
+  context 'when suggestions are disabled' do
+    before do
+      session.
+        run_command('bindkey ^B autosuggest-disable').
+        run_command('bindkey ^J autosuggest-previous').
+        send_keys('C-b')
+    end
+    it 'will fetch and display a suggestion' do
+      with_history('echo hello', 'echo world', 'echo joe') do
+        session.send_string('echo h')
+        sleep 1
+        expect(session.content).to eq('echo h')
+        session.send_keys('C-j')
+        wait_for { session.content }.to eq('echo hello')
+        session.send_string('e')
+        wait_for { session.content }.to eq('echo hello')
+      end
+    end
+  end
+
+  context 'invoked on a populated history' do
+    before do
+      session.
+        run_command('bindkey ^K autosuggest-next').
+        run_command('bindkey ^J autosuggest-previous')
+    end
+    it 'will cycle, fetch, and display a suggestion' do
+      with_history('echo hello', 'echo world', 'echo joe') do
+        session.send_string('echo')
+        sleep 1
+        expect(session.content).to eq('echo joe')
+        session.send_keys('C-k')
+        wait_for { session.content }.to eq('echo world')
+        session.send_keys('C-k')
+        wait_for { session.content }.to eq('echo hello')
+        session.send_keys('C-k')
+        wait_for { session.content }.to eq('echo hello')
+        session.send_keys('C-j')
+        wait_for { session.content }.to eq('echo world')
+        session.send_keys('C-j')
+        wait_for { session.content }.to eq('echo joe')
+        session.send_keys('C-j')
+        wait_for { session.content }.to eq('echo joe')
+      end
+    end
+  end
+
+  context 'when async mode is enabled' do
+    let(:options) { ['ZSH_AUTOSUGGEST_USE_ASYNC=true', 'ZSH_AUTOSUGGEST_STRATEGY=history'] }
+
+    before do
+      session.
+        run_command('bindkey ^K autosuggest-next').
+        run_command('bindkey ^J autosuggest-previous')
+    end
+    it 'will cycle, fetch, and display a suggestion' do
+      with_history('echo hello', 'echo world', 'echo joe') do
+        session.send_string('echo')
+        sleep 1
+        expect(session.content).to eq('echo joe')
+        session.send_keys('C-k')
+        wait_for { session.content }.to eq('echo world')
+        session.send_keys('C-k')
+        wait_for { session.content }.to eq('echo hello')
+        session.send_keys('C-k')
+        wait_for { session.content }.to eq('echo hello')
+        session.send_keys('C-j')
+        wait_for { session.content }.to eq('echo world')
+        session.send_keys('C-j')
+        wait_for { session.content }.to eq('echo joe')
+        session.send_keys('C-j')
+        wait_for { session.content }.to eq('echo joe')
+      end
+    end
+  end
+end

--- a/src/bind.zsh
+++ b/src/bind.zsh
@@ -76,7 +76,7 @@ _zsh_autosuggest_bind_widget() {
 _zsh_autosuggest_bind_widgets() {
 	emulate -L zsh
 
- 	local widget
+	local widget
 	local ignore_widgets
 
 	ignore_widgets=(

--- a/src/fetch.zsh
+++ b/src/fetch.zsh
@@ -7,6 +7,7 @@
 #
 
 _zsh_autosuggest_fetch_suggestion() {
+	typeset -g capped_history_index
 	typeset -g suggestion
 	local -a strategies
 	local strategy
@@ -16,7 +17,7 @@ _zsh_autosuggest_fetch_suggestion() {
 
 	for strategy in $strategies; do
 		# Try to get a suggestion from this strategy
-		_zsh_autosuggest_strategy_$strategy "$1"
+		_zsh_autosuggest_strategy_$strategy "$@"
 
 		# Break once we've found a suggestion
 		[[ -n "$suggestion" ]] && break

--- a/src/strategies/completion.zsh
+++ b/src/strategies/completion.zsh
@@ -75,6 +75,10 @@ _zsh_autosuggest_strategy_completion() {
 	typeset -g suggestion
 	local line REPLY
 
+	# Ignore index parameter, since it does not apply to this strategy
+	typeset -g capped_history_index=1
+	shift
+
 	# Exit if we don't have completions
 	whence compdef >/dev/null || return
 

--- a/src/strategies/history.zsh
+++ b/src/strategies/history.zsh
@@ -2,8 +2,8 @@
 #--------------------------------------------------------------------#
 # History Suggestion Strategy                                        #
 #--------------------------------------------------------------------#
-# Suggests the most recent history item that matches the given
-# prefix.
+# Suggests the history item that matches the given prefix and history
+# index
 #
 
 _zsh_autosuggest_strategy_history() {
@@ -13,13 +13,20 @@ _zsh_autosuggest_strategy_history() {
 	# Enable globbing flags so that we can use (#m)
 	setopt EXTENDED_GLOB
 
+	# Extract the paramenters for this function
+	typeset -g capped_history_index="${1}"
+	local query="${2}"
+
 	# Escape backslashes and all of the glob operators so we can use
 	# this string as a pattern to search the $history associative array.
 	# - (#m) globbing flag enables setting references for match data
 	# TODO: Use (b) flag when we can drop support for zsh older than v5.0.8
-	local prefix="${1//(#m)[\\*?[\]<>()|^~#]/\\$MATCH}"
+	local prefix="${query//(#m)[\\*?[\]<>()|^~#]/\\$MATCH}"
 
 	# Get the history items that match
-	# - (r) subscript flag makes the pattern match on values
-	typeset -g suggestion="${history[(r)${prefix}*]}"
+	# - (R) subscript flag makes the pattern match on values
+	# - (k) returns the entry indices instead of values
+	local suggestions=(${(k)history[(R)$prefix*]})
+	(( capped_history_index > $#suggestions )) && capped_history_index=${#suggestions}
+	typeset -g suggestion="${history[${suggestions[${capped_history_index}]}]}"
 }

--- a/src/strategies/match_prev_cmd.zsh
+++ b/src/strategies/match_prev_cmd.zsh
@@ -27,8 +27,12 @@ _zsh_autosuggest_strategy_match_prev_cmd() {
 	# Enable globbing flags so that we can use (#m)
 	setopt EXTENDED_GLOB
 
+	# Extract the paramenters for this function
+	typeset -g capped_history_index="${1}"
+	local query="${2}"
+
 	# TODO: Use (b) flag when we can drop support for zsh older than v5.0.8
-	local prefix="${1//(#m)[\\*?[\]<>()|^~#]/\\$MATCH}"
+	local prefix="${query//(#m)[\\*?[\]<>()|^~#]/\\$MATCH}"
 
 	# Get all history event numbers that correspond to history
 	# entries that match pattern $prefix*
@@ -36,13 +40,13 @@ _zsh_autosuggest_strategy_match_prev_cmd() {
 	history_match_keys=(${(k)history[(R)$prefix*]})
 
 	# By default we use the first history number (most recent history entry)
-	local histkey="${history_match_keys[1]}"
+	local histkey="${history_match_keys[capped_history_index]}"
 
 	# Get the previously executed command
 	local prev_cmd="$(_zsh_autosuggest_escape_command "${history[$((HISTCMD-1))]}")"
 
 	# Iterate up to the first 200 history event numbers that match $prefix
-	for key in "${(@)history_match_keys[1,200]}"; do
+	for key in "${(@)history_match_keys[capped_history_index,200]}"; do
 		# Stop if we ran out of history
 		[[ $key -gt 1 ]] || break
 


### PR DESCRIPTION
This change adds two widgets to the project. They work as a pair and allow to cycle up and down the suggestions without having to commit to a suggestion.

This works similarly to `zsh`'s <kbd>up</kbd> and <kbd>down</kbd>, but without filling the `BUFFER`. The user can then call `autosuggest_execute` or `autosuggest_accept`, or any other `zsh_autosuggestions` widget for that matter.
The cycling gets capped at the top and bottom of the history matches.