### PR TITLE
Features/no overwrite config

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ If you invoke the `forward-word` widget, it will partially accept the suggestion
 
 ## Configuration
 
-You may want to override the default global config variables after sourcing the plugin. Default values of these variables can be found [here](src/config.zsh).
+You may want to override the default global config variables. Default values of these variables can be found [here](src/config.zsh).
 
 **Note:** If you are using Oh My Zsh, you can put this configuration in a file in the `$ZSH_CUSTOM` directory. See their comments on [overriding internals](https://github.com/robbyrussell/oh-my-zsh/wiki/Customization#overriding-internals).
 

--- a/spec/options/strategy_spec.rb
+++ b/spec/options/strategy_spec.rb
@@ -3,7 +3,11 @@ describe 'a suggestion for a given prefix' do
   let(:foobar_strategy) { '_zsh_autosuggest_strategy_foobar() { [[ "foobar baz" = $1* ]] && suggestion="foobar baz" }' }
   let(:foobaz_strategy) { '_zsh_autosuggest_strategy_foobaz() { [[ "foobaz bar" = $1* ]] && suggestion="foobaz bar" }' }
 
-  let(:options) { [ history_strategy ] }
+  let(:after_sourcing) do
+    -> do
+      session.run_command(history_strategy)
+    end
+  end
 
   it 'by default is determined by calling the `history` strategy function' do
     session.send_string('h')
@@ -11,11 +15,14 @@ describe 'a suggestion for a given prefix' do
   end
 
   context 'when ZSH_AUTOSUGGEST_STRATEGY is set to an array' do
-    let(:options) { [
-      foobar_strategy,
-      foobaz_strategy,
-      'ZSH_AUTOSUGGEST_STRATEGY=(foobar foobaz)'
-    ] }
+    let(:after_sourcing) do
+      -> do
+        session.
+          run_command(foobar_strategy).
+          run_command(foobaz_strategy).
+          run_command('ZSH_AUTOSUGGEST_STRATEGY=(foobar foobaz)')
+      end
+    end
 
     it 'is determined by the first strategy function to return a suggestion' do
       session.send_string('foo')
@@ -27,11 +34,14 @@ describe 'a suggestion for a given prefix' do
   end
 
   context 'when ZSH_AUTOSUGGEST_STRATEGY is set to a string' do
-    let(:options) { [
-      foobar_strategy,
-      foobaz_strategy,
-      'ZSH_AUTOSUGGEST_STRATEGY="foobar foobaz"'
-    ] }
+    let(:after_sourcing) do
+      -> do
+        session.
+          run_command(foobar_strategy).
+          run_command(foobaz_strategy).
+          run_command('ZSH_AUTOSUGGEST_STRATEGY="foobar foobaz"')
+      end
+    end
 
     it 'is determined by the first strategy function to return a suggestion' do
       session.send_string('foo')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,8 +11,8 @@ RSpec.shared_context 'terminal session' do
 
   around do |example|
     before_sourcing.call
-
-    session.run_command((['source zsh-autosuggestions.zsh'] + options).join('; '))
+    session.run_command(options.join('; '))
+    session.run_command('source zsh-autosuggestions.zsh')
     after_sourcing.call
     session.clear_screen
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,12 +6,14 @@ RSpec.shared_context 'terminal session' do
   let(:term_opts) { {} }
   let(:session) { TerminalSession.new(term_opts) }
   let(:before_sourcing) { -> {} }
+  let(:after_sourcing) { -> {} }
   let(:options) { [] }
 
   around do |example|
     before_sourcing.call
 
     session.run_command((['source zsh-autosuggestions.zsh'] + options).join('; '))
+    after_sourcing.call
     session.clear_screen
 
     example.run

--- a/src/config.zsh
+++ b/src/config.zsh
@@ -6,17 +6,17 @@
 # Color to use when highlighting suggestion
 # Uses format of `region_highlight`
 # More info: http://zsh.sourceforge.net/Doc/Release/Zsh-Line-Editor.html#Zle-Widgets
-ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE='fg=8'
+: ${ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE='fg=8'}
 
 # Prefix to use when saving original versions of bound widgets
-ZSH_AUTOSUGGEST_ORIGINAL_WIDGET_PREFIX=autosuggest-orig-
+: ${ZSH_AUTOSUGGEST_ORIGINAL_WIDGET_PREFIX=autosuggest-orig-}
 
 # Strategies to use to fetch a suggestion
 # Will try each strategy in order until a suggestion is returned
-ZSH_AUTOSUGGEST_STRATEGY=(history)
+(( ! ${+ZSH_AUTOSUGGEST_STRATEGY} )) && ZSH_AUTOSUGGEST_STRATEGY=(history)
 
 # Widgets that clear the suggestion
-ZSH_AUTOSUGGEST_CLEAR_WIDGETS=(
+(( ! ${+ZSH_AUTOSUGGEST_CLEAR_WIDGETS} )) && ZSH_AUTOSUGGEST_CLEAR_WIDGETS=(
 	history-search-forward
 	history-search-backward
 	history-beginning-search-forward
@@ -31,7 +31,7 @@ ZSH_AUTOSUGGEST_CLEAR_WIDGETS=(
 )
 
 # Widgets that accept the entire suggestion
-ZSH_AUTOSUGGEST_ACCEPT_WIDGETS=(
+(( ! ${+ZSH_AUTOSUGGEST_ACCEPT_WIDGETS} )) && ZSH_AUTOSUGGEST_ACCEPT_WIDGETS=(
 	forward-char
 	end-of-line
 	vi-forward-char
@@ -40,11 +40,11 @@ ZSH_AUTOSUGGEST_ACCEPT_WIDGETS=(
 )
 
 # Widgets that accept the entire suggestion and execute it
-ZSH_AUTOSUGGEST_EXECUTE_WIDGETS=(
+(( ! ${+ZSH_AUTOSUGGEST_EXECUTE_WIDGETS} )) && ZSH_AUTOSUGGEST_EXECUTE_WIDGETS=(
 )
 
 # Widgets that accept the suggestion as far as the cursor moves
-ZSH_AUTOSUGGEST_PARTIAL_ACCEPT_WIDGETS=(
+(( ! ${+ZSH_AUTOSUGGEST_PARTIAL_ACCEPT_WIDGETS} )) && ZSH_AUTOSUGGEST_PARTIAL_ACCEPT_WIDGETS=(
 	forward-word
 	emacs-forward-word
 	vi-forward-word
@@ -56,7 +56,7 @@ ZSH_AUTOSUGGEST_PARTIAL_ACCEPT_WIDGETS=(
 )
 
 # Widgets that should be ignored (globbing supported but must be escaped)
-ZSH_AUTOSUGGEST_IGNORE_WIDGETS=(
+(( ! ${+ZSH_AUTOSUGGEST_IGNORE_WIDGETS} )) && ZSH_AUTOSUGGEST_IGNORE_WIDGETS=(
 	orig-\*
 	beep
 	run-help
@@ -66,8 +66,8 @@ ZSH_AUTOSUGGEST_IGNORE_WIDGETS=(
 	yank-pop
 )
 
-# Max size of buffer to trigger autosuggestion. Leave undefined for no upper bound.
-ZSH_AUTOSUGGEST_BUFFER_MAX_SIZE=
+# Max size of buffer to trigger autosuggestion. Leave null for no upper bound.
+: ${ZSH_AUTOSUGGEST_BUFFER_MAX_SIZE=}
 
 # Pty name for capturing completions for completion suggestion strategy
-ZSH_AUTOSUGGEST_COMPLETIONS_PTY_NAME=zsh_autosuggest_completion_pty
+: ${ZSH_AUTOSUGGEST_COMPLETIONS_PTY_NAME=zsh_autosuggest_completion_pty}

--- a/zsh-autosuggestions.zsh
+++ b/zsh-autosuggestions.zsh
@@ -32,17 +32,17 @@
 # Color to use when highlighting suggestion
 # Uses format of `region_highlight`
 # More info: http://zsh.sourceforge.net/Doc/Release/Zsh-Line-Editor.html#Zle-Widgets
-ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE='fg=8'
+: ${ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE='fg=8'}
 
 # Prefix to use when saving original versions of bound widgets
-ZSH_AUTOSUGGEST_ORIGINAL_WIDGET_PREFIX=autosuggest-orig-
+: ${ZSH_AUTOSUGGEST_ORIGINAL_WIDGET_PREFIX=autosuggest-orig-}
 
 # Strategies to use to fetch a suggestion
 # Will try each strategy in order until a suggestion is returned
-ZSH_AUTOSUGGEST_STRATEGY=(history)
+(( ! ${+ZSH_AUTOSUGGEST_STRATEGY} )) && ZSH_AUTOSUGGEST_STRATEGY=(history)
 
 # Widgets that clear the suggestion
-ZSH_AUTOSUGGEST_CLEAR_WIDGETS=(
+(( ! ${+ZSH_AUTOSUGGEST_CLEAR_WIDGETS} )) && ZSH_AUTOSUGGEST_CLEAR_WIDGETS=(
 	history-search-forward
 	history-search-backward
 	history-beginning-search-forward
@@ -57,7 +57,7 @@ ZSH_AUTOSUGGEST_CLEAR_WIDGETS=(
 )
 
 # Widgets that accept the entire suggestion
-ZSH_AUTOSUGGEST_ACCEPT_WIDGETS=(
+(( ! ${+ZSH_AUTOSUGGEST_ACCEPT_WIDGETS} )) && ZSH_AUTOSUGGEST_ACCEPT_WIDGETS=(
 	forward-char
 	end-of-line
 	vi-forward-char
@@ -66,11 +66,11 @@ ZSH_AUTOSUGGEST_ACCEPT_WIDGETS=(
 )
 
 # Widgets that accept the entire suggestion and execute it
-ZSH_AUTOSUGGEST_EXECUTE_WIDGETS=(
+(( ! ${+ZSH_AUTOSUGGEST_EXECUTE_WIDGETS} )) && ZSH_AUTOSUGGEST_EXECUTE_WIDGETS=(
 )
 
 # Widgets that accept the suggestion as far as the cursor moves
-ZSH_AUTOSUGGEST_PARTIAL_ACCEPT_WIDGETS=(
+(( ! ${+ZSH_AUTOSUGGEST_PARTIAL_ACCEPT_WIDGETS} )) && ZSH_AUTOSUGGEST_PARTIAL_ACCEPT_WIDGETS=(
 	forward-word
 	emacs-forward-word
 	vi-forward-word
@@ -82,7 +82,7 @@ ZSH_AUTOSUGGEST_PARTIAL_ACCEPT_WIDGETS=(
 )
 
 # Widgets that should be ignored (globbing supported but must be escaped)
-ZSH_AUTOSUGGEST_IGNORE_WIDGETS=(
+(( ! ${+ZSH_AUTOSUGGEST_IGNORE_WIDGETS} )) && ZSH_AUTOSUGGEST_IGNORE_WIDGETS=(
 	orig-\*
 	beep
 	run-help
@@ -92,11 +92,11 @@ ZSH_AUTOSUGGEST_IGNORE_WIDGETS=(
 	yank-pop
 )
 
-# Max size of buffer to trigger autosuggestion. Leave undefined for no upper bound.
-ZSH_AUTOSUGGEST_BUFFER_MAX_SIZE=
+# Max size of buffer to trigger autosuggestion. Leave null for no upper bound.
+: ${ZSH_AUTOSUGGEST_BUFFER_MAX_SIZE=}
 
 # Pty name for capturing completions for completion suggestion strategy
-ZSH_AUTOSUGGEST_COMPLETIONS_PTY_NAME=zsh_autosuggest_completion_pty
+: ${ZSH_AUTOSUGGEST_COMPLETIONS_PTY_NAME=zsh_autosuggest_completion_pty}
 
 #--------------------------------------------------------------------#
 # Utility Functions                                                  #


### PR DESCRIPTION
Builds on #378 but:

- uses `: ${var=thing}` instead of `: ${var:=thing}` for scalars and `[[ -z "${var+x}" ]]` instead of `(( ! ${#var} ))` for arrays so that we only set the config params if they are in fact unset, and not if they are just null (e.g. empty string, empty array).
- updates specs to set options _before_ the plugin is sourced instead of after.

@ericbn What do you think?