### PR TITLE
check for deprecated 'default' value

### DIFF
--- a/zsh-autosuggestions.zsh
+++ b/zsh-autosuggestions.zsh
@@ -49,7 +49,9 @@ zmodload zsh/zpty
 
 # Strategies to use to fetch a suggestion
 # Will try each strategy in order until a suggestion is returned
-(( ! ${+ZSH_AUTOSUGGEST_STRATEGY} )) && ZSH_AUTOSUGGEST_STRATEGY=(history)
+if (( ! ${+ZSH_AUTOSUGGEST_STRATEGY} )) || [ "$ZSH_AUTOSUGGEST_STRATEGY" = "default" ];then
+	ZSH_AUTOSUGGEST_STRATEGY=(history)
+fi
 
 # Widgets that clear the suggestion
 (( ! ${+ZSH_AUTOSUGGEST_CLEAR_WIDGETS} )) && ZSH_AUTOSUGGEST_CLEAR_WIDGETS=(


### PR DESCRIPTION
I found that my `$ZSH_CUSTOM/config.zsh` sets `ZSH_AUTOSUGGEST_STRATEGY=default`. I didn't put that there, so I'm guessing its being done by an installer somewhere. I couldn't find anything in the repo, maybe you know where that is happening? In any case, I'm pretty sure that other oh-my-zsh users will have the same issue as me, so I just added an explicit check for `[ ZSH_AUTOSUGGEST_STRATEGY = "default" ]`