### PR TITLE
Set global parameters with typeset -g

### DIFF
--- a/src/config.zsh
+++ b/src/config.zsh
@@ -6,68 +6,90 @@
 # Color to use when highlighting suggestion
 # Uses format of `region_highlight`
 # More info: http://zsh.sourceforge.net/Doc/Release/Zsh-Line-Editor.html#Zle-Widgets
-: ${ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE='fg=8'}
+(( ! ${+ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE} )) &&
+typeset -g ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE='fg=8'
 
 # Prefix to use when saving original versions of bound widgets
-: ${ZSH_AUTOSUGGEST_ORIGINAL_WIDGET_PREFIX=autosuggest-orig-}
+(( ! ${+ZSH_AUTOSUGGEST_ORIGINAL_WIDGET_PREFIX} )) &&
+typeset -g ZSH_AUTOSUGGEST_ORIGINAL_WIDGET_PREFIX=autosuggest-orig-
 
 # Strategies to use to fetch a suggestion
 # Will try each strategy in order until a suggestion is returned
-(( ! ${+ZSH_AUTOSUGGEST_STRATEGY} )) && ZSH_AUTOSUGGEST_STRATEGY=(history)
+(( ! ${+ZSH_AUTOSUGGEST_STRATEGY} )) && {
+	typeset -ga ZSH_AUTOSUGGEST_STRATEGY
+	ZSH_AUTOSUGGEST_STRATEGY=(history)
+}
 
 # Widgets that clear the suggestion
-(( ! ${+ZSH_AUTOSUGGEST_CLEAR_WIDGETS} )) && ZSH_AUTOSUGGEST_CLEAR_WIDGETS=(
-	history-search-forward
-	history-search-backward
-	history-beginning-search-forward
-	history-beginning-search-backward
-	history-substring-search-up
-	history-substring-search-down
-	up-line-or-beginning-search
-	down-line-or-beginning-search
-	up-line-or-history
-	down-line-or-history
-	accept-line
-)
+(( ! ${+ZSH_AUTOSUGGEST_CLEAR_WIDGETS} )) && {
+	typeset -ga ZSH_AUTOSUGGEST_CLEAR_WIDGETS
+	ZSH_AUTOSUGGEST_CLEAR_WIDGETS=(
+		history-search-forward
+		history-search-backward
+		history-beginning-search-forward
+		history-beginning-search-backward
+		history-substring-search-up
+		history-substring-search-down
+		up-line-or-beginning-search
+		down-line-or-beginning-search
+		up-line-or-history
+		down-line-or-history
+		accept-line
+	)
+}
 
 # Widgets that accept the entire suggestion
-(( ! ${+ZSH_AUTOSUGGEST_ACCEPT_WIDGETS} )) && ZSH_AUTOSUGGEST_ACCEPT_WIDGETS=(
-	forward-char
-	end-of-line
-	vi-forward-char
-	vi-end-of-line
-	vi-add-eol
-)
+(( ! ${+ZSH_AUTOSUGGEST_ACCEPT_WIDGETS} )) && {
+	typeset -ga ZSH_AUTOSUGGEST_ACCEPT_WIDGETS
+	ZSH_AUTOSUGGEST_ACCEPT_WIDGETS=(
+		forward-char
+		end-of-line
+		vi-forward-char
+		vi-end-of-line
+		vi-add-eol
+	)
+}
 
 # Widgets that accept the entire suggestion and execute it
-(( ! ${+ZSH_AUTOSUGGEST_EXECUTE_WIDGETS} )) && ZSH_AUTOSUGGEST_EXECUTE_WIDGETS=(
-)
+(( ! ${+ZSH_AUTOSUGGEST_EXECUTE_WIDGETS} )) && {
+	typeset -ga ZSH_AUTOSUGGEST_EXECUTE_WIDGETS
+	ZSH_AUTOSUGGEST_EXECUTE_WIDGETS=(
+	)
+}
 
 # Widgets that accept the suggestion as far as the cursor moves
-(( ! ${+ZSH_AUTOSUGGEST_PARTIAL_ACCEPT_WIDGETS} )) && ZSH_AUTOSUGGEST_PARTIAL_ACCEPT_WIDGETS=(
-	forward-word
-	emacs-forward-word
-	vi-forward-word
-	vi-forward-word-end
-	vi-forward-blank-word
-	vi-forward-blank-word-end
-	vi-find-next-char
-	vi-find-next-char-skip
-)
+(( ! ${+ZSH_AUTOSUGGEST_PARTIAL_ACCEPT_WIDGETS} )) && {
+	typeset -ga ZSH_AUTOSUGGEST_PARTIAL_ACCEPT_WIDGETS
+	ZSH_AUTOSUGGEST_PARTIAL_ACCEPT_WIDGETS=(
+		forward-word
+		emacs-forward-word
+		vi-forward-word
+		vi-forward-word-end
+		vi-forward-blank-word
+		vi-forward-blank-word-end
+		vi-find-next-char
+		vi-find-next-char-skip
+	)
+}
 
 # Widgets that should be ignored (globbing supported but must be escaped)
-(( ! ${+ZSH_AUTOSUGGEST_IGNORE_WIDGETS} )) && ZSH_AUTOSUGGEST_IGNORE_WIDGETS=(
-	orig-\*
-	beep
-	run-help
-	set-local-history
-	which-command
-	yank
-	yank-pop
-)
+(( ! ${+ZSH_AUTOSUGGEST_IGNORE_WIDGETS} )) && {
+	typeset -ga ZSH_AUTOSUGGEST_IGNORE_WIDGETS
+	ZSH_AUTOSUGGEST_IGNORE_WIDGETS=(
+		orig-\*
+		beep
+		run-help
+		set-local-history
+		which-command
+		yank
+		yank-pop
+	)
+}
 
 # Max size of buffer to trigger autosuggestion. Leave null for no upper bound.
-: ${ZSH_AUTOSUGGEST_BUFFER_MAX_SIZE=}
+(( ! ${+ZSH_AUTOSUGGEST_BUFFER_MAX_SIZE} )) &&
+typeset -g ZSH_AUTOSUGGEST_BUFFER_MAX_SIZE=
 
 # Pty name for calculating autosuggestions asynchronously
-: ${ZSH_AUTOSUGGEST_ASYNC_PTY_NAME=zsh_autosuggest_pty}
+(( ! ${+ZSH_AUTOSUGGEST_ASYNC_PTY_NAME} )) &&
+typeset -g ZSH_AUTOSUGGEST_ASYNC_PTY_NAME=zsh_autosuggest_pty

--- a/src/widgets.zsh
+++ b/src/widgets.zsh
@@ -190,22 +190,25 @@ _zsh_autosuggest_partial_accept() {
 	return $retval
 }
 
-for action in clear modify fetch suggest accept partial_accept execute enable disable toggle; do
-	eval "_zsh_autosuggest_widget_$action() {
-		local -i retval
+() {
+	local action
+	for action in clear modify fetch suggest accept partial_accept execute enable disable toggle; do
+		eval "_zsh_autosuggest_widget_$action() {
+			local -i retval
 
-		_zsh_autosuggest_highlight_reset
+			_zsh_autosuggest_highlight_reset
 
-		_zsh_autosuggest_$action \$@
-		retval=\$?
+			_zsh_autosuggest_$action \$@
+			retval=\$?
 
-		_zsh_autosuggest_highlight_apply
+			_zsh_autosuggest_highlight_apply
 
-		zle -R
+			zle -R
 
-		return \$retval
-	}"
-done
+			return \$retval
+		}"
+	done
+}
 
 zle -N autosuggest-fetch _zsh_autosuggest_widget_fetch
 zle -N autosuggest-suggest _zsh_autosuggest_widget_suggest

--- a/zsh-autosuggestions.zsh
+++ b/zsh-autosuggestions.zsh
@@ -42,71 +42,93 @@ zmodload zsh/zpty
 # Color to use when highlighting suggestion
 # Uses format of `region_highlight`
 # More info: http://zsh.sourceforge.net/Doc/Release/Zsh-Line-Editor.html#Zle-Widgets
-: ${ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE='fg=8'}
+(( ! ${+ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE} )) &&
+typeset -g ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE='fg=8'
 
 # Prefix to use when saving original versions of bound widgets
-: ${ZSH_AUTOSUGGEST_ORIGINAL_WIDGET_PREFIX=autosuggest-orig-}
+(( ! ${+ZSH_AUTOSUGGEST_ORIGINAL_WIDGET_PREFIX} )) &&
+typeset -g ZSH_AUTOSUGGEST_ORIGINAL_WIDGET_PREFIX=autosuggest-orig-
 
 # Strategies to use to fetch a suggestion
 # Will try each strategy in order until a suggestion is returned
-(( ! ${+ZSH_AUTOSUGGEST_STRATEGY} )) && ZSH_AUTOSUGGEST_STRATEGY=(history)
+(( ! ${+ZSH_AUTOSUGGEST_STRATEGY} )) && {
+	typeset -ga ZSH_AUTOSUGGEST_STRATEGY
+	ZSH_AUTOSUGGEST_STRATEGY=(history)
+}
 
 # Widgets that clear the suggestion
-(( ! ${+ZSH_AUTOSUGGEST_CLEAR_WIDGETS} )) && ZSH_AUTOSUGGEST_CLEAR_WIDGETS=(
-	history-search-forward
-	history-search-backward
-	history-beginning-search-forward
-	history-beginning-search-backward
-	history-substring-search-up
-	history-substring-search-down
-	up-line-or-beginning-search
-	down-line-or-beginning-search
-	up-line-or-history
-	down-line-or-history
-	accept-line
-)
+(( ! ${+ZSH_AUTOSUGGEST_CLEAR_WIDGETS} )) && {
+	typeset -ga ZSH_AUTOSUGGEST_CLEAR_WIDGETS
+	ZSH_AUTOSUGGEST_CLEAR_WIDGETS=(
+		history-search-forward
+		history-search-backward
+		history-beginning-search-forward
+		history-beginning-search-backward
+		history-substring-search-up
+		history-substring-search-down
+		up-line-or-beginning-search
+		down-line-or-beginning-search
+		up-line-or-history
+		down-line-or-history
+		accept-line
+	)
+}
 
 # Widgets that accept the entire suggestion
-(( ! ${+ZSH_AUTOSUGGEST_ACCEPT_WIDGETS} )) && ZSH_AUTOSUGGEST_ACCEPT_WIDGETS=(
-	forward-char
-	end-of-line
-	vi-forward-char
-	vi-end-of-line
-	vi-add-eol
-)
+(( ! ${+ZSH_AUTOSUGGEST_ACCEPT_WIDGETS} )) && {
+	typeset -ga ZSH_AUTOSUGGEST_ACCEPT_WIDGETS
+	ZSH_AUTOSUGGEST_ACCEPT_WIDGETS=(
+		forward-char
+		end-of-line
+		vi-forward-char
+		vi-end-of-line
+		vi-add-eol
+	)
+}
 
 # Widgets that accept the entire suggestion and execute it
-(( ! ${+ZSH_AUTOSUGGEST_EXECUTE_WIDGETS} )) && ZSH_AUTOSUGGEST_EXECUTE_WIDGETS=(
-)
+(( ! ${+ZSH_AUTOSUGGEST_EXECUTE_WIDGETS} )) && {
+	typeset -ga ZSH_AUTOSUGGEST_EXECUTE_WIDGETS
+	ZSH_AUTOSUGGEST_EXECUTE_WIDGETS=(
+	)
+}
 
 # Widgets that accept the suggestion as far as the cursor moves
-(( ! ${+ZSH_AUTOSUGGEST_PARTIAL_ACCEPT_WIDGETS} )) && ZSH_AUTOSUGGEST_PARTIAL_ACCEPT_WIDGETS=(
-	forward-word
-	emacs-forward-word
-	vi-forward-word
-	vi-forward-word-end
-	vi-forward-blank-word
-	vi-forward-blank-word-end
-	vi-find-next-char
-	vi-find-next-char-skip
-)
+(( ! ${+ZSH_AUTOSUGGEST_PARTIAL_ACCEPT_WIDGETS} )) && {
+	typeset -ga ZSH_AUTOSUGGEST_PARTIAL_ACCEPT_WIDGETS
+	ZSH_AUTOSUGGEST_PARTIAL_ACCEPT_WIDGETS=(
+		forward-word
+		emacs-forward-word
+		vi-forward-word
+		vi-forward-word-end
+		vi-forward-blank-word
+		vi-forward-blank-word-end
+		vi-find-next-char
+		vi-find-next-char-skip
+	)
+}
 
 # Widgets that should be ignored (globbing supported but must be escaped)
-(( ! ${+ZSH_AUTOSUGGEST_IGNORE_WIDGETS} )) && ZSH_AUTOSUGGEST_IGNORE_WIDGETS=(
-	orig-\*
-	beep
-	run-help
-	set-local-history
-	which-command
-	yank
-	yank-pop
-)
+(( ! ${+ZSH_AUTOSUGGEST_IGNORE_WIDGETS} )) && {
+	typeset -ga ZSH_AUTOSUGGEST_IGNORE_WIDGETS
+	ZSH_AUTOSUGGEST_IGNORE_WIDGETS=(
+		orig-\*
+		beep
+		run-help
+		set-local-history
+		which-command
+		yank
+		yank-pop
+	)
+}
 
 # Max size of buffer to trigger autosuggestion. Leave null for no upper bound.
-: ${ZSH_AUTOSUGGEST_BUFFER_MAX_SIZE=}
+(( ! ${+ZSH_AUTOSUGGEST_BUFFER_MAX_SIZE} )) &&
+typeset -g ZSH_AUTOSUGGEST_BUFFER_MAX_SIZE=
 
 # Pty name for calculating autosuggestions asynchronously
-: ${ZSH_AUTOSUGGEST_ASYNC_PTY_NAME=zsh_autosuggest_pty}
+(( ! ${+ZSH_AUTOSUGGEST_ASYNC_PTY_NAME} )) &&
+typeset -g ZSH_AUTOSUGGEST_ASYNC_PTY_NAME=zsh_autosuggest_pty
 
 #--------------------------------------------------------------------#
 # Utility Functions                                                  #
@@ -475,22 +497,25 @@ _zsh_autosuggest_partial_accept() {
 	return $retval
 }
 
-for action in clear modify fetch suggest accept partial_accept execute enable disable toggle; do
-	eval "_zsh_autosuggest_widget_$action() {
-		local -i retval
+() {
+	local action
+	for action in clear modify fetch suggest accept partial_accept execute enable disable toggle; do
+		eval "_zsh_autosuggest_widget_$action() {
+			local -i retval
 
-		_zsh_autosuggest_highlight_reset
+			_zsh_autosuggest_highlight_reset
 
-		_zsh_autosuggest_$action \$@
-		retval=\$?
+			_zsh_autosuggest_$action \$@
+			retval=\$?
 
-		_zsh_autosuggest_highlight_apply
+			_zsh_autosuggest_highlight_apply
 
-		zle -R
+			zle -R
 
-		return \$retval
-	}"
-done
+			return \$retval
+		}"
+	done
+}
 
 zle -N autosuggest-fetch _zsh_autosuggest_widget_fetch
 zle -N autosuggest-suggest _zsh_autosuggest_widget_suggest


### PR DESCRIPTION
I decided to turn on `warn_create_global` recently, but a lot of my `zshrc` stuff happens inside functions to prevent leaking temp variables, and zsh-autosuggestions doesn't like that:

```
% zsh --warn-create-global -fc '() { source ./zsh-autosuggestions.zsh }'
./zsh-autosuggestions.zsh:45: scalar parameter ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE created globally in function (anon)
./zsh-autosuggestions.zsh:48: scalar parameter ZSH_AUTOSUGGEST_ORIGINAL_WIDGET_PREFIX created globally in function (anon)
./zsh-autosuggestions.zsh:52: array parameter ZSH_AUTOSUGGEST_STRATEGY created globally in function (anon)
./zsh-autosuggestions.zsh:55: array parameter ZSH_AUTOSUGGEST_CLEAR_WIDGETS created globally in function (anon)
./zsh-autosuggestions.zsh:70: array parameter ZSH_AUTOSUGGEST_ACCEPT_WIDGETS created globally in function (anon)
./zsh-autosuggestions.zsh:79: array parameter ZSH_AUTOSUGGEST_EXECUTE_WIDGETS created globally in function (anon)
./zsh-autosuggestions.zsh:83: array parameter ZSH_AUTOSUGGEST_PARTIAL_ACCEPT_WIDGETS created globally in function (anon)
./zsh-autosuggestions.zsh:95: array parameter ZSH_AUTOSUGGEST_IGNORE_WIDGETS created globally in function (anon)
./zsh-autosuggestions.zsh:106: scalar parameter ZSH_AUTOSUGGEST_BUFFER_MAX_SIZE created globally in function (anon)
./zsh-autosuggestions.zsh:109: scalar parameter ZSH_AUTOSUGGEST_ASYNC_PTY_NAME created globally in function (anon)
./zsh-autosuggestions.zsh:478: scalar parameter action created globally in function (anon)
```

This seems to fix it