### PR TITLE
Speed up widget rebinding by removing redundant array subscripts

### DIFF
--- a/zsh-autosuggestions.zsh
+++ b/zsh-autosuggestions.zsh
@@ -143,21 +143,10 @@ _zsh_autosuggest_feature_detect_zpty_returns_fd() {
 #--------------------------------------------------------------------#
 
 _zsh_autosuggest_incr_bind_count() {
-	if ((${+_ZSH_AUTOSUGGEST_BIND_COUNTS[$1]})); then
-		((_ZSH_AUTOSUGGEST_BIND_COUNTS[$1]++))
-	else
-		_ZSH_AUTOSUGGEST_BIND_COUNTS[$1]=1
-	fi
-
-	typeset -gi bind_count=$_ZSH_AUTOSUGGEST_BIND_COUNTS[$1]
-}
-
-_zsh_autosuggest_get_bind_count() {
-	if ((${+_ZSH_AUTOSUGGEST_BIND_COUNTS[$1]})); then
-		typeset -gi bind_count=$_ZSH_AUTOSUGGEST_BIND_COUNTS[$1]
-	else
-		typeset -gi bind_count=0
-	fi
+  local C=${${_ZSH_AUTOSUGGEST_BIND_COUNTS[$1]}:-0}
+  ((++C))
+  _ZSH_AUTOSUGGEST_BIND_COUNTS[$1]=$C
+  typeset -gi bind_count=$C
 }
 
 # Bind a single widget to an autosuggest widget, saving a reference to the original widget
@@ -173,7 +162,9 @@ _zsh_autosuggest_bind_widget() {
 	# Save a reference to the original widget
 	case $widgets[$widget] in
 		# Already bound
-		user:_zsh_autosuggest_(bound|orig)_*);;
+		user:_zsh_autosuggest_(bound|orig)_*)
+		  bind_count=${${_ZSH_AUTOSUGGEST_BIND_COUNTS[$1]}:-0}
+		  ;;
 
 		# User-defined widget
 		user:*)
@@ -194,8 +185,6 @@ _zsh_autosuggest_bind_widget() {
 			eval "zle -C $prefix${bind_count}-${(q)widget} ${${(s.:.)widgets[$widget]}[2,3]}"
 			;;
 	esac
-
-	_zsh_autosuggest_get_bind_count $widget
 
 	# Pass the original widget's name explicitly into the autosuggest
 	# function. Use this passed in widget name to call the original


### PR DESCRIPTION
`_zsh_autosuggest_bind_widget` runs for every widget on every prompt. The bulk of its time is spend looking up data in `_ZSH_AUTOSUGGEST_BIND_COUNTS`. This PR speeds up `_zsh_autosuggest_bind_widget` by reducing the number of said lookups.

This results in perceptible latency reduction in my zsh setup, although I don't have the numbers to quantify the effect.
