### PR TITLE
Features/faster prompts

### DIFF
--- a/src/bind.zsh
+++ b/src/bind.zsh
@@ -4,21 +4,8 @@
 #--------------------------------------------------------------------#
 
 _zsh_autosuggest_incr_bind_count() {
-	if ((${+_ZSH_AUTOSUGGEST_BIND_COUNTS[$1]})); then
-		((_ZSH_AUTOSUGGEST_BIND_COUNTS[$1]++))
-	else
-		_ZSH_AUTOSUGGEST_BIND_COUNTS[$1]=1
-	fi
-
-	typeset -gi bind_count=$_ZSH_AUTOSUGGEST_BIND_COUNTS[$1]
-}
-
-_zsh_autosuggest_get_bind_count() {
-	if ((${+_ZSH_AUTOSUGGEST_BIND_COUNTS[$1]})); then
-		typeset -gi bind_count=$_ZSH_AUTOSUGGEST_BIND_COUNTS[$1]
-	else
-		typeset -gi bind_count=0
-	fi
+	typeset -gi bind_count=$((_ZSH_AUTOSUGGEST_BIND_COUNTS[$1]+1))
+	_ZSH_AUTOSUGGEST_BIND_COUNTS[$1]=$bind_count
 }
 
 # Bind a single widget to an autosuggest widget, saving a reference to the original widget
@@ -34,7 +21,9 @@ _zsh_autosuggest_bind_widget() {
 	# Save a reference to the original widget
 	case $widgets[$widget] in
 		# Already bound
-		user:_zsh_autosuggest_(bound|orig)_*);;
+		user:_zsh_autosuggest_(bound|orig)_*)
+			bind_count=$((_ZSH_AUTOSUGGEST_BIND_COUNTS[$widget]))
+			;;
 
 		# User-defined widget
 		user:*)
@@ -55,8 +44,6 @@ _zsh_autosuggest_bind_widget() {
 			eval "zle -C $prefix$bind_count-${(q)widget} ${${(s.:.)widgets[$widget]}[2,3]}"
 			;;
 	esac
-
-	_zsh_autosuggest_get_bind_count $widget
 
 	# Pass the original widget's name explicitly into the autosuggest
 	# function. Use this passed in widget name to call the original

--- a/src/bind.zsh
+++ b/src/bind.zsh
@@ -39,20 +39,20 @@ _zsh_autosuggest_bind_widget() {
 		# User-defined widget
 		user:*)
 			_zsh_autosuggest_incr_bind_count $widget
-			zle -N $prefix${bind_count}-$widget ${widgets[$widget]#*:}
+			zle -N $prefix$bind_count-$widget ${widgets[$widget]#*:}
 			;;
 
 		# Built-in widget
 		builtin)
 			_zsh_autosuggest_incr_bind_count $widget
 			eval "_zsh_autosuggest_orig_${(q)widget}() { zle .${(q)widget} }"
-			zle -N $prefix${bind_count}-$widget _zsh_autosuggest_orig_$widget
+			zle -N $prefix$bind_count-$widget _zsh_autosuggest_orig_$widget
 			;;
 
 		# Completion widget
 		completion:*)
 			_zsh_autosuggest_incr_bind_count $widget
-			eval "zle -C $prefix${bind_count}-${(q)widget} ${${(s.:.)widgets[$widget]}[2,3]}"
+			eval "zle -C $prefix$bind_count-${(q)widget} ${${(s.:.)widgets[$widget]}[2,3]}"
 			;;
 	esac
 

--- a/zsh-autosuggestions.zsh
+++ b/zsh-autosuggestions.zsh
@@ -200,20 +200,20 @@ _zsh_autosuggest_bind_widget() {
 		# User-defined widget
 		user:*)
 			_zsh_autosuggest_incr_bind_count $widget
-			zle -N $prefix${bind_count}-$widget ${widgets[$widget]#*:}
+			zle -N $prefix$bind_count-$widget ${widgets[$widget]#*:}
 			;;
 
 		# Built-in widget
 		builtin)
 			_zsh_autosuggest_incr_bind_count $widget
 			eval "_zsh_autosuggest_orig_${(q)widget}() { zle .${(q)widget} }"
-			zle -N $prefix${bind_count}-$widget _zsh_autosuggest_orig_$widget
+			zle -N $prefix$bind_count-$widget _zsh_autosuggest_orig_$widget
 			;;
 
 		# Completion widget
 		completion:*)
 			_zsh_autosuggest_incr_bind_count $widget
-			eval "zle -C $prefix${bind_count}-${(q)widget} ${${(s.:.)widgets[$widget]}[2,3]}"
+			eval "zle -C $prefix$bind_count-${(q)widget} ${${(s.:.)widgets[$widget]}[2,3]}"
 			;;
 	esac
 

--- a/zsh-autosuggestions.zsh
+++ b/zsh-autosuggestions.zsh
@@ -165,21 +165,8 @@ _zsh_autosuggest_feature_detect_zpty_returns_fd() {
 #--------------------------------------------------------------------#
 
 _zsh_autosuggest_incr_bind_count() {
-	if ((${+_ZSH_AUTOSUGGEST_BIND_COUNTS[$1]})); then
-		((_ZSH_AUTOSUGGEST_BIND_COUNTS[$1]++))
-	else
-		_ZSH_AUTOSUGGEST_BIND_COUNTS[$1]=1
-	fi
-
-	typeset -gi bind_count=$_ZSH_AUTOSUGGEST_BIND_COUNTS[$1]
-}
-
-_zsh_autosuggest_get_bind_count() {
-	if ((${+_ZSH_AUTOSUGGEST_BIND_COUNTS[$1]})); then
-		typeset -gi bind_count=$_ZSH_AUTOSUGGEST_BIND_COUNTS[$1]
-	else
-		typeset -gi bind_count=0
-	fi
+	typeset -gi bind_count=$((_ZSH_AUTOSUGGEST_BIND_COUNTS[$1]+1))
+	_ZSH_AUTOSUGGEST_BIND_COUNTS[$1]=$bind_count
 }
 
 # Bind a single widget to an autosuggest widget, saving a reference to the original widget
@@ -195,7 +182,9 @@ _zsh_autosuggest_bind_widget() {
 	# Save a reference to the original widget
 	case $widgets[$widget] in
 		# Already bound
-		user:_zsh_autosuggest_(bound|orig)_*);;
+		user:_zsh_autosuggest_(bound|orig)_*)
+			bind_count=$((_ZSH_AUTOSUGGEST_BIND_COUNTS[$widget]))
+			;;
 
 		# User-defined widget
 		user:*)
@@ -216,8 +205,6 @@ _zsh_autosuggest_bind_widget() {
 			eval "zle -C $prefix$bind_count-${(q)widget} ${${(s.:.)widgets[$widget]}[2,3]}"
 			;;
 	esac
-
-	_zsh_autosuggest_get_bind_count $widget
 
 	# Pass the original widget's name explicitly into the autosuggest
 	# function. Use this passed in widget name to call the original


### PR DESCRIPTION
Some modifications to @romkatv's PR #406.

- Made changes to `src/` files instead of to compiled `zsh-autosuggestions.zsh`
- Remove temporary variable in `_zsh_autosuggest_incr_bind_count` and use numeric context which evaluates undefined vars to zero
- PR against develop instead of master

Using @romkatv's benchmark tool, I'm seeing ~15ms prompt time for both this PR and #406, and ~20ms prompt time for master branch.