### PR TITLE
Wrap zle-line-init to support fetching suggestions on line init

### DIFF
--- a/spec/line_init_spec.rb
+++ b/spec/line_init_spec.rb
@@ -1,0 +1,17 @@
+context 'with zle-line-init unignored' do
+  let(:after_sourcing) do
+    -> do
+      session.
+        run_command('setopt extendedglob').
+        run_command('ZSH_AUTOSUGGEST_IGNORE_WIDGETS=(${(@)ZSH_AUTOSUGGEST_IGNORE_WIDGETS:#zle-\*} zle-\^line-init)').
+        run_command('zle-line-init() { BUFFER="echo" }')
+    end
+  end
+
+  it 'should fetch a suggestion on each line initialization' do
+    with_history('echo foo') do
+      session.run_command('zle -N zle-line-init')
+      wait_for { session.content }.to end_with('echo foo')
+    end
+  end
+end

--- a/src/bind.zsh
+++ b/src/bind.zsh
@@ -69,7 +69,6 @@ _zsh_autosuggest_bind_widgets() {
 	ignore_widgets=(
 		.\*
 		_\*
-		zle-\*
 		autosuggest-\*
 		$ZSH_AUTOSUGGEST_ORIGINAL_WIDGET_PREFIX\*
 		$ZSH_AUTOSUGGEST_IGNORE_WIDGETS

--- a/src/config.zsh
+++ b/src/config.zsh
@@ -84,6 +84,7 @@ typeset -g ZSH_AUTOSUGGEST_ORIGINAL_WIDGET_PREFIX=autosuggest-orig-
 		which-command
 		yank
 		yank-pop
+		zle-\*
 	)
 }
 

--- a/zsh-autosuggestions.zsh
+++ b/zsh-autosuggestions.zsh
@@ -110,6 +110,7 @@ typeset -g ZSH_AUTOSUGGEST_ORIGINAL_WIDGET_PREFIX=autosuggest-orig-
 		which-command
 		yank
 		yank-pop
+		zle-\*
 	)
 }
 
@@ -198,7 +199,6 @@ _zsh_autosuggest_bind_widgets() {
 	ignore_widgets=(
 		.\*
 		_\*
-		zle-\*
 		autosuggest-\*
 		$ZSH_AUTOSUGGEST_ORIGINAL_WIDGET_PREFIX\*
 		$ZSH_AUTOSUGGEST_IGNORE_WIDGETS


### PR DESCRIPTION
Use case suggested by @romkatv uses zle-line-init to restore buffer after running a widget to cd up one level (GitHub #431).

As far as I can tell, the ignoring of zle-line-* was added in commit 9788c2e to support some deprecation warnings that were removed some time ago.

The pattern was then widened in commit 0c940e7 to zle-* to fix problems encountered when wrapping zle-isearch-update.

This commit removes the hard coded ignore of all zle-* widgets and puts zle-isearch-update and zle-keymap-select into the default list of widgets to be ignored. It leaves zle-line-init and zle-line-finish not ignored so that suggestions will be fetched after they are run.