### PR TITLE
Don't fetch suggestions after copy-earlier-word

### DIFF
--- a/spec/async_spec.rb
+++ b/spec/async_spec.rb
@@ -27,6 +27,29 @@ context 'with asynchronous suggestions enabled' do
     end
   end
 
+  describe '`copy-earlier-word`' do
+    let(:before_sourcing) do
+      -> do
+        session.
+          run_command('autoload -Uz copy-earlier-word').
+          run_command('zle -N copy-earlier-word').
+          run_command('bindkey "^N" copy-earlier-word')
+      end
+    end
+
+    it 'should cycle through previous words in the buffer' do
+      session.clear_screen
+      session.send_string('foo bar baz')
+      sleep 0.5
+      session.send_keys('C-n')
+      wait_for { session.content }.to eq('foo bar bazbaz')
+      session.send_keys('C-n')
+      wait_for { session.content }.to eq('foo bar bazbar')
+      session.send_keys('C-n')
+      wait_for { session.content }.to eq('foo bar bazfoo')
+    end
+  end
+
   describe 'pressing ^C after fetching a suggestion' do
     before do
       skip 'Workaround does not work below v5.0.8' if session.zsh_version < Gem::Version.new('5.0.8')

--- a/spec/async_spec.rb
+++ b/spec/async_spec.rb
@@ -34,9 +34,9 @@ context 'with asynchronous suggestions enabled' do
 
     it 'terminates the prompt and begins a new one' do
       session.send_keys('e')
-      sleep 0.1
+      sleep 0.5
       session.send_keys('C-c')
-      sleep 0.1
+      sleep 0.5
       session.send_keys('echo')
 
       wait_for { session.content }.to eq("e\necho")

--- a/src/config.zsh
+++ b/src/config.zsh
@@ -35,6 +35,7 @@ typeset -g ZSH_AUTOSUGGEST_ORIGINAL_WIDGET_PREFIX=autosuggest-orig-
 		up-line-or-history
 		down-line-or-history
 		accept-line
+		copy-earlier-word
 	)
 }
 

--- a/zsh-autosuggestions.zsh
+++ b/zsh-autosuggestions.zsh
@@ -71,6 +71,7 @@ typeset -g ZSH_AUTOSUGGEST_ORIGINAL_WIDGET_PREFIX=autosuggest-orig-
 		up-line-or-history
 		down-line-or-history
 		accept-line
+		copy-earlier-word
 	)
 }
 


### PR DESCRIPTION
Supercedes #438. Thanks @henrebotha!

Like `{up,down}-line-or-beginning-search`, this widget relies on `$LASTWIDGET` being set to function correctly on subsequent invocations.

When asynchronous suggestions are enabled, and the widget triggers a suggestion to be fetched, `autosuggest-suggest` will be called and `$LASTWIDGET` will be set to it.