### PR TITLE
Added 'function' keyword

### DIFF
--- a/zsh-autosuggestions.zsh
+++ b/zsh-autosuggestions.zsh
@@ -568,7 +568,7 @@ _zsh_autosuggest_capture_completion_async() {
 	# https://stackoverflow.com/a/7057118/154703
 	autoload +X _complete
 	functions[_original_complete]=$functions[_complete]
-	_complete () {
+	function _complete () {
 		unset 'compstate[vared]'
 		_original_complete "$@"
 	}


### PR DESCRIPTION
After installation of the plugin I've got following errors:
```
/home/user/.oh-my-zsh/custom/plugins/zsh-autosuggestions/zsh-autosuggestions.zsh:9: defining function based on alias `_complete'
/home/user/.oh-my-zsh/custom/plugins/zsh-autosuggestions/zsh-autosuggestions.zsh:571: parse error near `()'
```
It turned out that there is a lack of 'function' keyword near '_complete' function.
Here's a simple fix.