### PR TITLE
Degrade gracefully on systems missing zsh/system module

### DIFF
--- a/src/async.zsh
+++ b/src/async.zsh
@@ -3,9 +3,9 @@
 # Async                                                              #
 #--------------------------------------------------------------------#
 
-zmodload zsh/system
-
 _zsh_autosuggest_async_request() {
+	zmodload zsh/system 2>/dev/null # For `$sysparams`
+
 	typeset -g _ZSH_AUTOSUGGEST_ASYNC_FD _ZSH_AUTOSUGGEST_CHILD_PID
 
 	# If we've got a pending request, cancel it
@@ -14,17 +14,20 @@ _zsh_autosuggest_async_request() {
 		exec {_ZSH_AUTOSUGGEST_ASYNC_FD}<&-
 		zle -F $_ZSH_AUTOSUGGEST_ASYNC_FD
 
-		# Zsh will make a new process group for the child process only if job
-		# control is enabled (MONITOR option)
-		if [[ -o MONITOR ]]; then
-			# Send the signal to the process group to kill any processes that may
-			# have been forked by the suggestion strategy
-			kill -TERM -$_ZSH_AUTOSUGGEST_CHILD_PID 2>/dev/null
-		else
-			# Kill just the child process since it wasn't placed in a new process
-			# group. If the suggestion strategy forked any child processes they may
-			# be orphaned and left behind.
-			kill -TERM $_ZSH_AUTOSUGGEST_CHILD_PID 2>/dev/null
+		# We won't know the pid unless the user has zsh/system module installed
+		if [[ -n "$_ZSH_AUTOSUGGEST_CHILD_PID" ]]; then
+			# Zsh will make a new process group for the child process only if job
+			# control is enabled (MONITOR option)
+			if [[ -o MONITOR ]]; then
+				# Send the signal to the process group to kill any processes that may
+				# have been forked by the suggestion strategy
+				kill -TERM -$_ZSH_AUTOSUGGEST_CHILD_PID 2>/dev/null
+			else
+				# Kill just the child process since it wasn't placed in a new process
+				# group. If the suggestion strategy forked any child processes they may
+				# be orphaned and left behind.
+				kill -TERM $_ZSH_AUTOSUGGEST_CHILD_PID 2>/dev/null
+			fi
 		fi
 	fi
 

--- a/zsh-autosuggestions.zsh
+++ b/zsh-autosuggestions.zsh
@@ -726,9 +726,9 @@ _zsh_autosuggest_fetch_suggestion() {
 # Async                                                              #
 #--------------------------------------------------------------------#
 
-zmodload zsh/system
-
 _zsh_autosuggest_async_request() {
+	zmodload zsh/system 2>/dev/null # For `$sysparams`
+
 	typeset -g _ZSH_AUTOSUGGEST_ASYNC_FD _ZSH_AUTOSUGGEST_CHILD_PID
 
 	# If we've got a pending request, cancel it
@@ -737,17 +737,20 @@ _zsh_autosuggest_async_request() {
 		exec {_ZSH_AUTOSUGGEST_ASYNC_FD}<&-
 		zle -F $_ZSH_AUTOSUGGEST_ASYNC_FD
 
-		# Zsh will make a new process group for the child process only if job
-		# control is enabled (MONITOR option)
-		if [[ -o MONITOR ]]; then
-			# Send the signal to the process group to kill any processes that may
-			# have been forked by the suggestion strategy
-			kill -TERM -$_ZSH_AUTOSUGGEST_CHILD_PID 2>/dev/null
-		else
-			# Kill just the child process since it wasn't placed in a new process
-			# group. If the suggestion strategy forked any child processes they may
-			# be orphaned and left behind.
-			kill -TERM $_ZSH_AUTOSUGGEST_CHILD_PID 2>/dev/null
+		# We won't know the pid unless the user has zsh/system module installed
+		if [[ -n "$_ZSH_AUTOSUGGEST_CHILD_PID" ]]; then
+			# Zsh will make a new process group for the child process only if job
+			# control is enabled (MONITOR option)
+			if [[ -o MONITOR ]]; then
+				# Send the signal to the process group to kill any processes that may
+				# have been forked by the suggestion strategy
+				kill -TERM -$_ZSH_AUTOSUGGEST_CHILD_PID 2>/dev/null
+			else
+				# Kill just the child process since it wasn't placed in a new process
+				# group. If the suggestion strategy forked any child processes they may
+				# be orphaned and left behind.
+				kill -TERM $_ZSH_AUTOSUGGEST_CHILD_PID 2>/dev/null
+			fi
 		fi
 	fi
 


### PR DESCRIPTION
When using async mode, stale background processes will not be cancelled when a new one starts. This shouldn't cause any real issues since the processes should eventually finish and be cleaned up anyway, and removing the handler with `zle -F` means that stale suggestions should never be shown.

Closes #441.