### PR TITLE
Possible fix for #416

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE="fg=#ff00ff,bg=cyan,bold,underline"
 
 For more info, read the Character Highlighting section of the zsh manual: `man zshzle` or [online](http://zsh.sourceforge.net/Doc/Release/Zsh-Line-Editor.html#Character-Highlighting).
 
+**Note:** Some iTerm2 users have reported [not being able to see the suggestions](https://github.com/zsh-users/zsh-autosuggestions/issues/416#issuecomment-486516333). If this affects you, the problem is likely caused by incorrect color settings. In order to correct this, go into iTerm2's setting, navigate to profile > colors and make sure that the colors for Basic Colors > Background and ANSI Colors > Bright Black are **different**.
+
 
 ### Suggestion Strategy
 
@@ -106,8 +108,7 @@ bindkey '^ ' autosuggest-accept
 
 ## Troubleshooting
 
-If you have a problem, please search through [the list of issues on GitHub](https://github.com/zsh-users/zsh-autosuggestions/issues) to see if someone else has already reported it.
-
+If you have a problem, please search through [the list of issues on GitHub](https://github.com/zsh-users/zsh-autosuggestions/issues?q=) to see if someone else has already reported it.
 
 ### Reporting an Issue
 


### PR DESCRIPTION
In reply to https://github.com/zsh-users/zsh-autosuggestions/issues/416#issuecomment-503621106, this PR contains the following changes to README.md:

* Added a note for iTerm2 users under readme/configuration/highlight style.
* Changed the link to the issue list under troubleshooting so that the default filters (only open issues) are not applied.