### PR TITLE
Fix deleting last character in vi mode (#302)

### DIFF
--- a/spec/integrations/vi_mode_spec.rb
+++ b/spec/integrations/vi_mode_spec.rb
@@ -63,5 +63,18 @@ describe 'when using vi mode' do
       end
     end
   end
-end
 
+  describe '`vi-delete`' do
+    it 'should be able to remove the last character in the buffer' do
+      skip 'deleting last char did not work below zsh version 5.0.8' if session.zsh_version < Gem::Version.new('5.0.8')
+
+      session.
+        send_string('echo foo').
+        send_keys('escape').
+        send_keys('d').
+        send_keys('l')
+
+      wait_for { session.content }.to eq('echo fo')
+    end
+  end
+end

--- a/src/widgets.zsh
+++ b/src/widgets.zsh
@@ -136,7 +136,7 @@ _zsh_autosuggest_accept() {
 		unset POSTDISPLAY
 
 		# Move the cursor to the end of the buffer
-		CURSOR=${#BUFFER}
+		CURSOR=${max_cursor_pos}
 	fi
 
 	_zsh_autosuggest_invoke_original_widget $@

--- a/zsh-autosuggestions.zsh
+++ b/zsh-autosuggestions.zsh
@@ -398,7 +398,7 @@ _zsh_autosuggest_accept() {
 		unset POSTDISPLAY
 
 		# Move the cursor to the end of the buffer
-		CURSOR=${#BUFFER}
+		CURSOR=${max_cursor_pos}
 	fi
 
 	_zsh_autosuggest_invoke_original_widget $@


### PR DESCRIPTION
Typing `d` and then `l` runs `vi-delete` and then `vi-forward-char`.  However, by default, `vi-forward-char` is configured to accept the suggestion. So in that case, the suggestion was being accepted and the cursor set to the end of the buffer before the deletion was run.

The reason the user doesn't see the suggestion accepted is that `vi-delete` doesn't finish until the movement widget is run, so we're already inside of a `modify` when `accept` is called. `modify` unsets `POSTDISPLAY` before calling the original widget so when we get to the accept function, `POSTDISPLAY` is empty and thus accepting the suggestion is a no-op.

The fix is to make sure we reset the cursor to the correct place before running the original widget.

We skip the test for versions of zsh below 5.0.8 since there was a bug in earlier versions where deleting the last char did not work. See http://www.zsh.org/mla/workers/2014/msg01316.html