### PR TITLE
Fix moving cursor to end of buffer when suggestion accepted

### DIFF
--- a/spec/options/widget_lists_spec.rb
+++ b/spec/options/widget_lists_spec.rb
@@ -5,12 +5,13 @@ describe 'a zle widget' do
   context 'when added to ZSH_AUTOSUGGEST_ACCEPT_WIDGETS' do
     let(:options) { ["ZSH_AUTOSUGGEST_ACCEPT_WIDGETS+=(#{widget})"] }
 
-    it 'accepts the suggestion when invoked' do
+    it 'accepts the suggestion and moves the cursor to the end of the buffer when invoked' do
       with_history('echo hello') do
         session.send_string('e')
         wait_for { session.content }.to eq('echo hello')
         session.send_keys('C-b')
         wait_for { session.content(esc_seqs: true) }.to eq('echo hello')
+        wait_for { session.cursor }.to eq([10, 0])
       end
     end
   end

--- a/src/widgets.zsh
+++ b/src/widgets.zsh
@@ -136,7 +136,11 @@ _zsh_autosuggest_accept() {
 		unset POSTDISPLAY
 
 		# Move the cursor to the end of the buffer
-		CURSOR=${max_cursor_pos}
+		if [[ "$KEYMAP" = "vicmd" ]]; then
+			CURSOR=$(($#BUFFER - 1))
+		else
+			CURSOR=$#BUFFER
+		fi
 	fi
 
 	_zsh_autosuggest_invoke_original_widget $@

--- a/zsh-autosuggestions.zsh
+++ b/zsh-autosuggestions.zsh
@@ -398,7 +398,11 @@ _zsh_autosuggest_accept() {
 		unset POSTDISPLAY
 
 		# Move the cursor to the end of the buffer
-		CURSOR=${max_cursor_pos}
+		if [[ "$KEYMAP" = "vicmd" ]]; then
+			CURSOR=$(($#BUFFER - 1))
+		else
+			CURSOR=$#BUFFER
+		fi
 	fi
 
 	_zsh_autosuggest_invoke_original_widget $@


### PR DESCRIPTION
`$max_cursor_pos` in this case was not the correct value to use. It was calculated based on the old length of the `$BUFFER`. After the suggestion is accepted, we need to recalculate the new max cursor length and use it to set the `$CURSOR`.

Fixes issue #452. Follow-up to issue #302 (PR #450).