### PR TITLE
Add package links to install docs (#222)

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,26 +1,22 @@
 # Installation
 
-* [Manual](#manual-git-clone)
+* [Packages](#packages)
 * [Antigen](#antigen)
 * [Oh My Zsh](#oh-my-zsh)
-* [Arch Linux](#arch-linux)
-* [macOS via Homebrew](#macos-via-homebrew)
+* [Manual](#manual-git-clone)
 
-## Manual (Git Clone)
+## Packages
 
-1. Clone this repository somewhere on your machine. This guide will assume `~/.zsh/zsh-autosuggestions`.
-
-    ```sh
-    git clone https://github.com/zsh-users/zsh-autosuggestions ~/.zsh/zsh-autosuggestions
-    ```
-
-2. Add the following to your `.zshrc`:
-
-    ```sh
-    source ~/.zsh/zsh-autosuggestions/zsh-autosuggestions.zsh
-    ```
-
-3. Start a new terminal session.
+| System  | Package |
+| ------------- | ------------- |
+| Debian / Ubuntu | [zsh-autosuggestions OBS repository](https://software.opensuse.org/download.html?project=shells%3Azsh-users%3Azsh-autosuggestions&package=zsh-autosuggestions) |
+| Fedora / CentOS / RHEL / Scientific Linux | [zsh-autosuggestions OBS repository](https://software.opensuse.org/download.html?project=shells%3Azsh-users%3Azsh-autosuggestions&package=zsh-autosuggestions) |
+| OpenSUSE / SLE | [zsh-autosuggestions OBS repository](https://software.opensuse.org/download.html?project=shells%3Azsh-users%3Azsh-autosuggestions&package=zsh-autosuggestions) |
+| Arch Linux / Manjaro / Antergos / Hyperbola | [zsh-autosuggestions](https://www.archlinux.org/packages/zsh-autosuggestions), [zsh-autosuggestions-git](https://aur.archlinux.org/packages/zsh-autosuggestions-git) |
+| NixOS | [zsh-autosuggestions](https://github.com/NixOS/nixpkgs/blob/master/pkgs/shells/zsh/zsh-autosuggestions/default.nix) |
+| Void Linux | [zsh-autosuggestions](https://github.com/void-linux/void-packages/blob/master/srcpkgs/zsh-autosuggestions/template) |
+| Mac OS | [homebrew](https://github.com/Homebrew/homebrew-core/blob/master/Formula/zsh-autosuggestions.rb)  |
+| NetBSD | [pkgsrc](http://ftp.netbsd.org/pub/pkgsrc/current/pkgsrc/shells/zsh-autosuggestions/README.html)  |
 
 ## Antigen
 
@@ -48,36 +44,18 @@
 
 3. Start a new terminal session.
 
-## Arch Linux
+## Manual (Git Clone)
 
-1. Install [`zsh-autosuggestions`](https://www.archlinux.org/packages/community/any/zsh-autosuggestions/) from the `community` repository.
-
-    ```sh
-    pacman -S zsh-autosuggestions
-    ```
-
-    or, to use a package based on the `master` branch, install [`zsh-autosuggestions-git`](https://aur.archlinux.org/packages/zsh-autosuggestions-git/) from the [AUR](https://wiki.archlinux.org/index.php/Arch_User_Repository).
-
-2. Add the following to your `.zshrc`:
+1. Clone this repository somewhere on your machine. This guide will assume `~/.zsh/zsh-autosuggestions`.
 
     ```sh
-    source /usr/share/zsh/plugins/zsh-autosuggestions/zsh-autosuggestions.zsh
-    ```
-
-3. Start a new terminal session.
-
-## macOS via Homebrew
-
-1. Install the `zsh-autosuggestions` package using [Homebrew](https://brew.sh/).
-
-    ```sh
-    brew install zsh-autosuggestions
+    git clone https://github.com/zsh-users/zsh-autosuggestions ~/.zsh/zsh-autosuggestions
     ```
 
 2. Add the following to your `.zshrc`:
 
     ```sh
-    source /usr/local/share/zsh-autosuggestions/zsh-autosuggestions.zsh
+    source ~/.zsh/zsh-autosuggestions/zsh-autosuggestions.zsh
     ```
 
 3. Start a new terminal session.


### PR DESCRIPTION
Hey @nicoulaj, I'm finally getting to issue #222. I just copied what you had for zsh-completions and `s/completions/autosuggestions/g`.

Got 404's (or equivalent) for Gentoo, Slackware, and MacPorts so went ahead and removed those.

Would appreciate if you could review when/if you have time. Thanks!