### PR TITLE
cleanup: Split on null bytes instead of pattern matching

### DIFF
--- a/src/strategies/completion.zsh
+++ b/src/strategies/completion.zsh
@@ -122,7 +122,7 @@ _zsh_autosuggest_strategy_completion() {
 		# versions of zsh (older than 5.3), we sometimes get extra bytes after
 		# the second null byte, so trim those off the end.
 		# See http://www.zsh.org/mla/workers/2015/msg03290.html
-		suggestion="${${line#*$'\0'}%$'\0'*}"
+		suggestion="${${(@0)line}[2]}"
 	} always {
 		# Destroy the pty
 		zpty -d $ZSH_AUTOSUGGEST_COMPLETIONS_PTY_NAME

--- a/zsh-autosuggestions.zsh
+++ b/zsh-autosuggestions.zsh
@@ -608,7 +608,7 @@ _zsh_autosuggest_strategy_completion() {
 		# versions of zsh (older than 5.3), we sometimes get extra bytes after
 		# the second null byte, so trim those off the end.
 		# See http://www.zsh.org/mla/workers/2015/msg03290.html
-		suggestion="${${line#*$'\0'}%$'\0'*}"
+		suggestion="${${(@0)line}[2]}"
 	} always {
 		# Destroy the pty
 		zpty -d $ZSH_AUTOSUGGEST_COMPLETIONS_PTY_NAME


### PR DESCRIPTION
Follow-up to technique tried in commit d94475c after I learned about the `@` flag to keep empty strings in the array.