### PR TITLE
Fix circle ci build issues

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,6 @@ jobs:
     shell: /bin/bash --login
     docker:
     - image: ericfreese/zsh-autosuggestions-test:latest
-      command: /sbin/init
     steps:
     - checkout
     - run:


### PR DESCRIPTION
We are getting errors on circle ci builds (e.g. see https://circleci.com/gh/zsh-users/zsh-autosuggestions/381):

> CircleCI was unable to run the job runner because we were unable to execute commands in build container.
> 
> This typically means that the build container entrypoint or command is terminating the container prematurely, or interfering with executed commands.  Consider clearing entrypoint/command values and try again.

Folks in [this thread](https://discuss.circleci.com/t/circleci-was-unable-to-run-the-job-runner/31894/18) suggest removing the `command: /sbin/init` line initially [added by the v1 => v2 migration script](https://github.com/zsh-users/zsh-autosuggestions/commit/affe7c687e329f881ae92e95670979b0f728e613#diff-1d37e48f9ceff6d8030570cd36286a61R32).