### PR TITLE
Allow skipping completion suggestions when buffer matches a pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,12 @@ Set `ZSH_AUTOSUGGEST_HISTORY_IGNORE` to a glob pattern to prevent offering sugge
 
 **Note:** This only affects the `history` and `match_prev_cmd` suggestion strategies.
 
+### Skipping completion suggestions for certain cases
+
+Set `ZSH_AUTOSUGGEST_COMPLETION_IGNORE` to a glob pattern to prevent offering completion suggestions when the buffer matches that pattern. For example, set it to `"git *"` to disable completion suggestions for git subcommands.
+
+**Note:** This only affects the `completion` suggestion strategy.
+
 
 ### Key Bindings
 

--- a/spec/strategies/completion_spec.rb
+++ b/spec/strategies/completion_spec.rb
@@ -5,7 +5,9 @@ describe 'the `completion` suggestion strategy' do
       session.
         run_command('autoload compinit && compinit').
         run_command('_foo() { compadd bar; compadd bat }').
-        run_command('compdef _foo baz')
+        run_command('_num() { compadd two; compadd three }').
+        run_command('compdef _foo baz').
+        run_command('compdef _num one')
     end
   end
 
@@ -34,6 +36,21 @@ describe 'the `completion` suggestion strategy' do
     it 'suggests the first completion result' do
       session.send_string('baz ')
       wait_for { session.content }.to eq('baz bar')
+    end
+  end
+
+  context 'when ZSH_AUTOSUGGEST_COMPLETION_IGNORE is set to a pattern' do
+    let(:options) { ['ZSH_AUTOSUGGEST_STRATEGY=completion', 'ZSH_AUTOSUGGEST_COMPLETION_IGNORE="one *"'] }
+
+    it 'makes suggestions when the buffer does not match the pattern' do
+      session.send_string('baz ')
+      wait_for { session.content }.to eq('baz bar')
+    end
+
+    it 'does not make suggestions when the buffer matches the pattern' do
+      session.send_string('one t')
+      sleep 1
+      expect(session.content).to eq('one t')
     end
   end
 

--- a/src/strategies/completion.zsh
+++ b/src/strategies/completion.zsh
@@ -96,6 +96,12 @@ _zsh_autosuggest_capture_completion_async() {
 }
 
 _zsh_autosuggest_strategy_completion() {
+	# Reset options to defaults and enable LOCAL_OPTIONS
+	emulate -L zsh
+
+	# Enable extended glob for completion ignore pattern
+	setopt EXTENDED_GLOB
+
 	typeset -g suggestion
 	local line REPLY
 
@@ -104,6 +110,9 @@ _zsh_autosuggest_strategy_completion() {
 
 	# Exit if we don't have zpty
 	zmodload zsh/zpty 2>/dev/null || return
+
+	# Exit if our search string matches the ignore pattern
+	[[ -n "$ZSH_AUTOSUGGEST_COMPLETION_IGNORE" ]] && [[ "$1" == $~ZSH_AUTOSUGGEST_COMPLETION_IGNORE ]] && return
 
 	# Zle will be inactive if we are in async mode
 	if zle; then

--- a/zsh-autosuggestions.zsh
+++ b/zsh-autosuggestions.zsh
@@ -582,6 +582,12 @@ _zsh_autosuggest_capture_completion_async() {
 }
 
 _zsh_autosuggest_strategy_completion() {
+	# Reset options to defaults and enable LOCAL_OPTIONS
+	emulate -L zsh
+
+	# Enable extended glob for completion ignore pattern
+	setopt EXTENDED_GLOB
+
 	typeset -g suggestion
 	local line REPLY
 
@@ -590,6 +596,9 @@ _zsh_autosuggest_strategy_completion() {
 
 	# Exit if we don't have zpty
 	zmodload zsh/zpty 2>/dev/null || return
+
+	# Exit if our search string matches the ignore pattern
+	[[ -n "$ZSH_AUTOSUGGEST_COMPLETION_IGNORE" ]] && [[ "$1" == $~ZSH_AUTOSUGGEST_COMPLETION_IGNORE ]] && return
 
 	# Zle will be inactive if we are in async mode
 	if zle; then


### PR DESCRIPTION
Set ZSH_AUTOSUGGEST_COMPLETION_IGNORE to a glob pattern to have the completion suggestion strategy never make suggestions when the buffer matches the pattern.

This can be helpful when some completion routines you have are particularly expensive and you want to prevent them from running automatically on every keystroke.

See GitHub issue #463.