### PR TITLE
Call original widget before moving cursor when accepting suggestion

### DIFF
--- a/src/widgets.zsh
+++ b/src/widgets.zsh
@@ -128,7 +128,7 @@ _zsh_autosuggest_accept() {
 	fi
 
 	# Only accept if the cursor is at the end of the buffer
-	if [[ $CURSOR = $max_cursor_pos ]]; then
+	if (( $CURSOR == $max_cursor_pos )); then
 		# Add the suggestion to the buffer
 		BUFFER="$BUFFER$POSTDISPLAY"
 

--- a/src/widgets.zsh
+++ b/src/widgets.zsh
@@ -127,20 +127,23 @@ _zsh_autosuggest_accept() {
 		max_cursor_pos=$((max_cursor_pos - 1))
 	fi
 
+	if (( $CURSOR != $max_cursor_pos )); then
+		_zsh_autosuggest_invoke_original_widget $@
+		return
+	fi
+
 	# Only accept if the cursor is at the end of the buffer
-	if (( $CURSOR == $max_cursor_pos )); then
-		# Add the suggestion to the buffer
-		BUFFER="$BUFFER$POSTDISPLAY"
+	# Add the suggestion to the buffer
+	BUFFER="$BUFFER$POSTDISPLAY"
 
-		# Remove the suggestion
-		unset POSTDISPLAY
+	# Remove the suggestion
+	unset POSTDISPLAY
 
-		# Move the cursor to the end of the buffer
-		if [[ "$KEYMAP" = "vicmd" ]]; then
-			CURSOR=$(($#BUFFER - 1))
-		else
-			CURSOR=$#BUFFER
-		fi
+	# Move the cursor to the end of the buffer
+	if [[ "$KEYMAP" = "vicmd" ]]; then
+		CURSOR=$(($#BUFFER - 1))
+	else
+		CURSOR=$#BUFFER
 	fi
 
 	_zsh_autosuggest_invoke_original_widget $@

--- a/src/widgets.zsh
+++ b/src/widgets.zsh
@@ -56,7 +56,7 @@ _zsh_autosuggest_modify() {
 	emulate -L zsh
 
 	# Don't fetch a new suggestion if there's more input to be read immediately
-	if (( $PENDING > 0 )) || (( $KEYS_QUEUED_COUNT > 0 )); then
+	if (( $PENDING > 0 || $KEYS_QUEUED_COUNT > 0 )); then
 		POSTDISPLAY="$orig_postdisplay"
 		return $retval
 	fi

--- a/src/widgets.zsh
+++ b/src/widgets.zsh
@@ -119,7 +119,7 @@ _zsh_autosuggest_suggest() {
 
 # Accept the entire suggestion
 _zsh_autosuggest_accept() {
-	local -i max_cursor_pos=$#BUFFER
+	local -i retval max_cursor_pos=$#BUFFER
 
 	# When vicmd keymap is active, the cursor can't move all the way
 	# to the end of the buffer
@@ -127,7 +127,9 @@ _zsh_autosuggest_accept() {
 		max_cursor_pos=$((max_cursor_pos - 1))
 	fi
 
-	if (( $CURSOR != $max_cursor_pos )); then
+	# If we're not in a valid state to accept a suggestion, just run the
+	# original widget and bail out
+	if (( $CURSOR != $max_cursor_pos || !$#POSTDISPLAY )); then
 		_zsh_autosuggest_invoke_original_widget $@
 		return
 	fi
@@ -139,6 +141,11 @@ _zsh_autosuggest_accept() {
 	# Remove the suggestion
 	unset POSTDISPLAY
 
+	# Run the original widget before manually moving the cursor so that the
+	# cursor movement doesn't make the widget do something unexpected
+	_zsh_autosuggest_invoke_original_widget $@
+	retval=$?
+
 	# Move the cursor to the end of the buffer
 	if [[ "$KEYMAP" = "vicmd" ]]; then
 		CURSOR=$(($#BUFFER - 1))
@@ -146,7 +153,7 @@ _zsh_autosuggest_accept() {
 		CURSOR=$#BUFFER
 	fi
 
-	_zsh_autosuggest_invoke_original_widget $@
+	return $retval
 }
 
 # Accept the entire suggestion and execute it

--- a/zsh-autosuggestions.zsh
+++ b/zsh-autosuggestions.zsh
@@ -318,7 +318,7 @@ _zsh_autosuggest_modify() {
 	emulate -L zsh
 
 	# Don't fetch a new suggestion if there's more input to be read immediately
-	if (( $PENDING > 0 )) || (( $KEYS_QUEUED_COUNT > 0 )); then
+	if (( $PENDING > 0 || $KEYS_QUEUED_COUNT > 0 )); then
 		POSTDISPLAY="$orig_postdisplay"
 		return $retval
 	fi

--- a/zsh-autosuggestions.zsh
+++ b/zsh-autosuggestions.zsh
@@ -389,20 +389,23 @@ _zsh_autosuggest_accept() {
 		max_cursor_pos=$((max_cursor_pos - 1))
 	fi
 
+	if (( $CURSOR != $max_cursor_pos )); then
+		_zsh_autosuggest_invoke_original_widget $@
+		return
+	fi
+
 	# Only accept if the cursor is at the end of the buffer
-	if (( $CURSOR == $max_cursor_pos )); then
-		# Add the suggestion to the buffer
-		BUFFER="$BUFFER$POSTDISPLAY"
+	# Add the suggestion to the buffer
+	BUFFER="$BUFFER$POSTDISPLAY"
 
-		# Remove the suggestion
-		unset POSTDISPLAY
+	# Remove the suggestion
+	unset POSTDISPLAY
 
-		# Move the cursor to the end of the buffer
-		if [[ "$KEYMAP" = "vicmd" ]]; then
-			CURSOR=$(($#BUFFER - 1))
-		else
-			CURSOR=$#BUFFER
-		fi
+	# Move the cursor to the end of the buffer
+	if [[ "$KEYMAP" = "vicmd" ]]; then
+		CURSOR=$(($#BUFFER - 1))
+	else
+		CURSOR=$#BUFFER
 	fi
 
 	_zsh_autosuggest_invoke_original_widget $@

--- a/zsh-autosuggestions.zsh
+++ b/zsh-autosuggestions.zsh
@@ -390,7 +390,7 @@ _zsh_autosuggest_accept() {
 	fi
 
 	# Only accept if the cursor is at the end of the buffer
-	if [[ $CURSOR = $max_cursor_pos ]]; then
+	if (( $CURSOR == $max_cursor_pos )); then
 		# Add the suggestion to the buffer
 		BUFFER="$BUFFER$POSTDISPLAY"
 


### PR DESCRIPTION
The check on length of `$POSTDISPLAY` is in support of the test for `vi-delete` on the last char of the buffer with `dl`.

Fixes issue #482.

I think this also supersedes PR #294.