### PR TITLE
Be more specific about the built-in widgets we want to avoid wrapping

### DIFF
--- a/src/bind.zsh
+++ b/src/bind.zsh
@@ -69,7 +69,7 @@ _zsh_autosuggest_bind_widgets() {
 	ignore_widgets=(
 		.\*
 		_\*
-		autosuggest-\*
+		${_ZSH_AUTOSUGGEST_BUILTIN_ACTIONS/#/autosuggest-}
 		$ZSH_AUTOSUGGEST_ORIGINAL_WIDGET_PREFIX\*
 		$ZSH_AUTOSUGGEST_IGNORE_WIDGETS
 	)

--- a/src/widgets.zsh
+++ b/src/widgets.zsh
@@ -205,8 +205,21 @@ _zsh_autosuggest_partial_accept() {
 }
 
 () {
+	typeset -ga _ZSH_AUTOSUGGEST_BUILTIN_ACTIONS
+
+	_ZSH_AUTOSUGGEST_BUILTIN_ACTIONS=(
+		clear
+		fetch
+		suggest
+		accept
+		execute
+		enable
+		disable
+		toggle
+	)
+
 	local action
-	for action in clear modify fetch suggest accept partial_accept execute enable disable toggle; do
+	for action in $_ZSH_AUTOSUGGEST_BUILTIN_ACTIONS modify partial_accept; do
 		eval "_zsh_autosuggest_widget_$action() {
 			local -i retval
 
@@ -223,12 +236,7 @@ _zsh_autosuggest_partial_accept() {
 		}"
 	done
 
-	zle -N autosuggest-fetch _zsh_autosuggest_widget_fetch
-	zle -N autosuggest-suggest _zsh_autosuggest_widget_suggest
-	zle -N autosuggest-accept _zsh_autosuggest_widget_accept
-	zle -N autosuggest-clear _zsh_autosuggest_widget_clear
-	zle -N autosuggest-execute _zsh_autosuggest_widget_execute
-	zle -N autosuggest-enable _zsh_autosuggest_widget_enable
-	zle -N autosuggest-disable _zsh_autosuggest_widget_disable
-	zle -N autosuggest-toggle _zsh_autosuggest_widget_toggle
+	for action in $_ZSH_AUTOSUGGEST_BUILTIN_ACTIONS; do
+		zle -N autosuggest-$action _zsh_autosuggest_widget_$action
+	done
 }

--- a/zsh-autosuggestions.zsh
+++ b/zsh-autosuggestions.zsh
@@ -467,8 +467,21 @@ _zsh_autosuggest_partial_accept() {
 }
 
 () {
+	typeset -ga _ZSH_AUTOSUGGEST_BUILTIN_ACTIONS
+
+	_ZSH_AUTOSUGGEST_BUILTIN_ACTIONS=(
+		clear
+		fetch
+		suggest
+		accept
+		execute
+		enable
+		disable
+		toggle
+	)
+
 	local action
-	for action in clear modify fetch suggest accept partial_accept execute enable disable toggle; do
+	for action in $_ZSH_AUTOSUGGEST_BUILTIN_ACTIONS modify partial_accept; do
 		eval "_zsh_autosuggest_widget_$action() {
 			local -i retval
 
@@ -485,14 +498,9 @@ _zsh_autosuggest_partial_accept() {
 		}"
 	done
 
-	zle -N autosuggest-fetch _zsh_autosuggest_widget_fetch
-	zle -N autosuggest-suggest _zsh_autosuggest_widget_suggest
-	zle -N autosuggest-accept _zsh_autosuggest_widget_accept
-	zle -N autosuggest-clear _zsh_autosuggest_widget_clear
-	zle -N autosuggest-execute _zsh_autosuggest_widget_execute
-	zle -N autosuggest-enable _zsh_autosuggest_widget_enable
-	zle -N autosuggest-disable _zsh_autosuggest_widget_disable
-	zle -N autosuggest-toggle _zsh_autosuggest_widget_toggle
+	for action in $_ZSH_AUTOSUGGEST_BUILTIN_ACTIONS; do
+		zle -N autosuggest-$action _zsh_autosuggest_widget_$action
+	done
 }
 
 #--------------------------------------------------------------------#

--- a/zsh-autosuggestions.zsh
+++ b/zsh-autosuggestions.zsh
@@ -199,7 +199,7 @@ _zsh_autosuggest_bind_widgets() {
 	ignore_widgets=(
 		.\*
 		_\*
-		autosuggest-\*
+		${_ZSH_AUTOSUGGEST_BUILTIN_ACTIONS/#/autosuggest-}
 		$ZSH_AUTOSUGGEST_ORIGINAL_WIDGET_PREFIX\*
 		$ZSH_AUTOSUGGEST_IGNORE_WIDGETS
 	)


### PR DESCRIPTION
To avoid wrapping the built-in widgets (e.g. `autosuggest-fetch`, `autosuggest-toggle`), we were ignoring all widgets whose names start with `autosuggest-`. This had the downside of preventing wrapping of user-defined widgets whose names happened to also start with that prefix.

By being more specific about the exact built-in widgets we want to avoid wrapping, we can allow users to define widgets whose names start with `autosuggest-`.


See #496.