### PR TITLE
Enable async mode by default in newer versions of zsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,11 @@ Widgets that modify the buffer and are not found in any of these arrays will fet
 Set `ZSH_AUTOSUGGEST_BUFFER_MAX_SIZE` to an integer value to disable autosuggestion for large buffers. The default is unset, which means that autosuggestion will be tried for any buffer size. Recommended value is 20.
 This can be useful when pasting large amount of text in the terminal, to avoid triggering autosuggestion for strings that are too long.
 
-### Enable Asynchronous Mode
+### Asynchronous Mode
 
-As of `v0.4.0`, suggestions can be fetched asynchronously. To enable this behavior, set the `ZSH_AUTOSUGGEST_USE_ASYNC` variable (it can be set to anything).
+Suggestions are fetched asynchronously by default in zsh versions 5.0.8 and greater. To disable asynchronous suggestions and fetch them synchronously instead, `unset ZSH_AUTOSUGGEST_USE_ASYNC` after sourcing the plugin.
+
+Alternatively, if you are using a version of zsh older than 5.0.8 and want to enable asynchronous mode, set the `ZSH_AUTOSUGGEST_USE_ASYNC` variable after sourcing the plugin (it can be set to anything). Note that there is [a bug](https://github.com/zsh-users/zsh-autosuggestions/issues/364#issuecomment-481423232) in versions of zsh older than 5.0.8 where <kbd>ctrl</kbd> + <kbd>c</kbd> will fail to reset the prompt immediately after fetching a suggestion asynchronously.
 
 ### Disabling automatic widget re-binding
 

--- a/spec/options/use_async_spec.rb
+++ b/spec/options/use_async_spec.rb
@@ -1,7 +1,0 @@
-describe 'suggestion fetching' do
-  it 'is performed synchronously'
-
-  context 'when ZSH_AUTOSUGGEST_USE_ASYNC is set' do
-    it 'is performed asynchronously'
-  end
-end

--- a/src/start.zsh
+++ b/src/start.zsh
@@ -18,6 +18,8 @@ _zsh_autosuggest_start() {
 	_zsh_autosuggest_bind_widgets
 }
 
+# Mark for auto-loading the functions that we use
+autoload -Uz add-zsh-hook is-at-least
+
 # Start the autosuggestion widgets on the next precmd
-autoload -Uz add-zsh-hook
 add-zsh-hook precmd _zsh_autosuggest_start

--- a/src/start.zsh
+++ b/src/start.zsh
@@ -21,5 +21,13 @@ _zsh_autosuggest_start() {
 # Mark for auto-loading the functions that we use
 autoload -Uz add-zsh-hook is-at-least
 
+# Automatically enable asynchronous mode in newer versions of zsh. Disable for
+# older versions because there is a bug when using async mode where ^C does not
+# work immediately after fetching a suggestion.
+# See https://github.com/zsh-users/zsh-autosuggestions/issues/364
+if is-at-least 5.0.8; then
+	typeset -g ZSH_AUTOSUGGEST_USE_ASYNC=
+fi
+
 # Start the autosuggestion widgets on the next precmd
 add-zsh-hook precmd _zsh_autosuggest_start

--- a/src/strategies/completion.zsh
+++ b/src/strategies/completion.zsh
@@ -45,8 +45,6 @@ _zsh_autosuggest_capture_completion_widget() {
 zle -N autosuggest-capture-completion _zsh_autosuggest_capture_completion_widget
 
 _zsh_autosuggest_capture_setup() {
-	autoload -Uz is-at-least
-
 	# There is a bug in zpty module in older zsh versions by which a
 	# zpty that exits will kill all zpty processes that were forked
 	# before it. Here we set up a zsh exit hook to SIGKILL the zpty

--- a/zsh-autosuggestions.zsh
+++ b/zsh-autosuggestions.zsh
@@ -541,8 +541,6 @@ _zsh_autosuggest_capture_completion_widget() {
 zle -N autosuggest-capture-completion _zsh_autosuggest_capture_completion_widget
 
 _zsh_autosuggest_capture_setup() {
-	autoload -Uz is-at-least
-
 	# There is a bug in zpty module in older zsh versions by which a
 	# zpty that exits will kill all zpty processes that were forked
 	# before it. Here we set up a zsh exit hook to SIGKILL the zpty
@@ -853,6 +851,8 @@ _zsh_autosuggest_start() {
 	_zsh_autosuggest_bind_widgets
 }
 
+# Mark for auto-loading the functions that we use
+autoload -Uz add-zsh-hook is-at-least
+
 # Start the autosuggestion widgets on the next precmd
-autoload -Uz add-zsh-hook
 add-zsh-hook precmd _zsh_autosuggest_start

--- a/zsh-autosuggestions.zsh
+++ b/zsh-autosuggestions.zsh
@@ -854,5 +854,13 @@ _zsh_autosuggest_start() {
 # Mark for auto-loading the functions that we use
 autoload -Uz add-zsh-hook is-at-least
 
+# Automatically enable asynchronous mode in newer versions of zsh. Disable for
+# older versions because there is a bug when using async mode where ^C does not
+# work immediately after fetching a suggestion.
+# See https://github.com/zsh-users/zsh-autosuggestions/issues/364
+if is-at-least 5.0.8; then
+	typeset -g ZSH_AUTOSUGGEST_USE_ASYNC=
+fi
+
 # Start the autosuggestion widgets on the next precmd
 add-zsh-hook precmd _zsh_autosuggest_start


### PR DESCRIPTION
Allow users to override the default by unsetting (or setting) the `ZSH_AUTOSUGGEST_USE_ASYNC` variable.

See GitHub issue #498.