### PR TITLE
Allow loading the plugin in the background

### DIFF
--- a/src/start.zsh
+++ b/src/start.zsh
@@ -21,5 +21,11 @@ _zsh_autosuggest_start() {
 # Mark for auto-loading the functions that we use
 autoload -Uz add-zsh-hook is-at-least
 
-# Start the autosuggestion widgets on the next precmd
-add-zsh-hook precmd _zsh_autosuggest_start
+# If zle is already running, go ahead and start the autosuggestion widgets.
+# Otherwise, wait until the next precmd.
+if zle; then
+	_zsh_autosuggest_start
+	(( ! ${+ZSH_AUTOSUGGEST_MANUAL_REBIND} )) && add-zsh-hook precmd _zsh_autosuggest_start
+else
+	add-zsh-hook precmd _zsh_autosuggest_start
+fi

--- a/src/start.zsh
+++ b/src/start.zsh
@@ -18,6 +18,8 @@ _zsh_autosuggest_start() {
 	_zsh_autosuggest_bind_widgets
 }
 
+# Mark for auto-loading the functions that we use
+autoload -Uz add-zsh-hook is-at-least
+
 # Start the autosuggestion widgets on the next precmd
-autoload -Uz add-zsh-hook
 add-zsh-hook precmd _zsh_autosuggest_start

--- a/src/strategies/completion.zsh
+++ b/src/strategies/completion.zsh
@@ -45,8 +45,6 @@ _zsh_autosuggest_capture_completion_widget() {
 zle -N autosuggest-capture-completion _zsh_autosuggest_capture_completion_widget
 
 _zsh_autosuggest_capture_setup() {
-	autoload -Uz is-at-least
-
 	# There is a bug in zpty module in older zsh versions by which a
 	# zpty that exits will kill all zpty processes that were forked
 	# before it. Here we set up a zsh exit hook to SIGKILL the zpty

--- a/zsh-autosuggestions.zsh
+++ b/zsh-autosuggestions.zsh
@@ -541,8 +541,6 @@ _zsh_autosuggest_capture_completion_widget() {
 zle -N autosuggest-capture-completion _zsh_autosuggest_capture_completion_widget
 
 _zsh_autosuggest_capture_setup() {
-	autoload -Uz is-at-least
-
 	# There is a bug in zpty module in older zsh versions by which a
 	# zpty that exits will kill all zpty processes that were forked
 	# before it. Here we set up a zsh exit hook to SIGKILL the zpty
@@ -853,6 +851,8 @@ _zsh_autosuggest_start() {
 	_zsh_autosuggest_bind_widgets
 }
 
+# Mark for auto-loading the functions that we use
+autoload -Uz add-zsh-hook is-at-least
+
 # Start the autosuggestion widgets on the next precmd
-autoload -Uz add-zsh-hook
 add-zsh-hook precmd _zsh_autosuggest_start

--- a/zsh-autosuggestions.zsh
+++ b/zsh-autosuggestions.zsh
@@ -854,5 +854,11 @@ _zsh_autosuggest_start() {
 # Mark for auto-loading the functions that we use
 autoload -Uz add-zsh-hook is-at-least
 
-# Start the autosuggestion widgets on the next precmd
-add-zsh-hook precmd _zsh_autosuggest_start
+# If zle is already running, go ahead and start the autosuggestion widgets.
+# Otherwise, wait until the next precmd.
+if zle; then
+	_zsh_autosuggest_start
+	(( ! ${+ZSH_AUTOSUGGEST_MANUAL_REBIND} )) && add-zsh-hook precmd _zsh_autosuggest_start
+else
+	add-zsh-hook precmd _zsh_autosuggest_start
+fi


### PR DESCRIPTION
If zle is already active (plugin has been loaded in the background), just start the widgets and set up the automatic re-binding (if manual rebind has not been specified).

See GitHub issue #481