### PR TITLE
Add additional missing installation instructions for Manjaro/Arch Linux

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -18,6 +18,15 @@
 | Mac OS | [homebrew](https://github.com/Homebrew/homebrew-core/blob/master/Formula/zsh-autosuggestions.rb)  |
 | NetBSD | [pkgsrc](http://ftp.netbsd.org/pub/pkgsrc/current/pkgsrc/shells/zsh-autosuggestions/README.html)  |
 
+## Arch Linux / Manjaro / Antergos / Hyperbola
+
+1. Install **zsh-autosuggestions** using the package listed in the table above.
+
+2. Add the following to your `.zshrc`:
+```sh
+source /usr/share/zsh/plugins/zsh-autosuggestions/zsh-autosuggestions.zsh
+```
+
 ## Antigen
 
 1. Add the following to your `.zshrc`:


### PR DESCRIPTION
I added missing instructions for installation on Manjaro and Arch Linux. These instructions were once present in this file, I don't know why they got removed.
I searched for a while for this missing step so I think everyone should be aware of it, otherwise the installation just doesn't work.