### PR TITLE
Fixes/flaky ci

### DIFF
--- a/spec/multi_line_spec.rb
+++ b/spec/multi_line_spec.rb
@@ -1,11 +1,6 @@
 describe 'a multi-line suggestion' do
   it 'should be displayed on multiple lines' do
-    with_history(-> {
-      session.send_string('echo "')
-      session.send_keys('enter')
-      session.send_string('"')
-      session.send_keys('enter')
-    }) do
+    with_history("echo \"\n\"") do
       session.send_keys('e')
       wait_for { session.content }.to eq("echo \"\n\"")
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 require 'pry'
 require 'rspec/wait'
 require 'terminal_session'
+require 'tempfile'
 
 RSpec.shared_context 'terminal session' do
   let(:term_opts) { {} }
@@ -21,18 +22,20 @@ RSpec.shared_context 'terminal session' do
   end
 
   def with_history(*commands, &block)
-    session.run_command('fc -p')
+    Tempfile.create do |f|
+      f.write(commands.map{|c| c.gsub("\n", "\\\n")}.join("\n"))
+      f.flush
 
-    commands.each do |c|
-      c.respond_to?(:call) ? c.call : session.run_command(c)
+      session.run_command('fc -p')
+      session.run_command("fc -R #{f.path}")
+
+      session.clear_screen
+
+      yield block
+
+      session.send_keys('C-c')
+      session.run_command('fc -P')
     end
-
-    session.clear_screen
-
-    yield block
-
-    session.send_keys('C-c')
-    session.run_command('fc -P')
   end
 end
 

--- a/spec/strategies/special_characters_helper.rb
+++ b/spec/strategies/special_characters_helper.rb
@@ -1,58 +1,71 @@
 shared_examples 'special characters' do
-  describe 'a special character in the buffer' do
-    it 'should be treated like any other character' do
+  describe 'a special character in the buffer should be treated like any other character' do
+    it 'asterisk' do
       with_history('echo "hello*"', 'echo "hello."') do
         session.send_string('echo "hello*')
         wait_for { session.content }.to eq('echo "hello*"')
       end
+    end
 
+    it 'question mark' do
       with_history('echo "hello?"', 'echo "hello."') do
         session.send_string('echo "hello?')
         wait_for { session.content }.to eq('echo "hello?"')
       end
+    end
 
+    it 'backslash' do
       with_history('echo "hello\nworld"') do
         session.send_string('echo "hello\\')
         wait_for { session.content }.to eq('echo "hello\nworld"')
       end
+    end
 
+    it 'double backslash' do
       with_history('echo "\\\\"') do
         session.send_string('echo "\\\\')
         wait_for { session.content }.to eq('echo "\\\\"')
       end
+    end
 
+    it 'tilde' do
       with_history('echo ~/foo') do
         session.send_string('echo ~')
         wait_for { session.content }.to eq('echo ~/foo')
       end
+    end
 
+    it 'parentheses' do
       with_history('echo "$(ls foo)"') do
         session.send_string('echo "$(')
         wait_for { session.content }.to eq('echo "$(ls foo)"')
       end
+    end
 
+    it 'square bracket' do
       with_history('echo "$history[123]"') do
         session.send_string('echo "$history[')
         wait_for { session.content }.to eq('echo "$history[123]"')
         session.send_string('123]')
         wait_for { session.content }.to eq('echo "$history[123]"')
       end
+    end
 
+    it 'octothorpe' do
       with_history('echo "#yolo"') do
         session.send_string('echo "#')
         wait_for { session.content }.to eq('echo "#yolo"')
       end
+    end
 
-      with_history('echo "#foo"', 'echo $#abc') do
-        session.send_string('echo "#')
-        wait_for { session.content }.to eq('echo "#foo"')
-      end
-
+    it 'caret' do
       with_history('echo "^A"', 'echo "^B"') do
         session.send_string('echo "^A')
         wait_for { session.content }.to eq('echo "^A"')
       end
+    end
 
+    it 'dash' do
       with_history('-foo() {}') do
         session.send_string('-')
         wait_for { session.content }.to eq('-foo() {}')


### PR DESCRIPTION
### Rewrite `with_history` test helper to be more robust

Write mock history to a temp file and load it directly with `fc -R` instead of running each command individually to build up the history.

### Fix flaky special char specs by not using `with_history` twice per test

There's something funny occasionally happening when `with_history` is used twice in the same test. It seems to be happening more frequently since asynchronous mode was enabled by default. My guess is it has something to do with the `C-c` keys being sent toward the end not consistently terminating the prompt. But I'm really not sure how it would ever get into a `then` block like it seems to:

```
Failure/Error: wait_for { session.content }.to eq('echo "hello\nworld"')

  expected: "echo \"hello\\nworld\""
       got: "then> echo \"hello\\"
```

Sticking to only one `with_history` per terminal session (per test) seems to fix the flakiness.

I also removed an old test case because I could not understand why it was necessary and so couldn't write a good description for it. Could be we'll need to add it back in at some point.