### PR TITLE
Ignore compiled files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignore compiled files
+*.zwc


### PR DESCRIPTION
When compiling before sourcing the plugin, a `zsh-autosuggestions.zsh.zwc` is created.
This can be annoying if zsh-autosuggestions is used as a git submodule in a dotfile repo for example, since the repository will then be marked as dirty.
This PR just adds a gitignore that ignores all files ending on `.zwc`.