### PR TITLE
Disable ^C async workaround for zsh version 5.8 and later

### DIFF
--- a/src/async.zsh
+++ b/src/async.zsh
@@ -44,7 +44,8 @@ _zsh_autosuggest_async_request() {
 
 	# There's a weird bug here where ^C stops working unless we force a fork
 	# See https://github.com/zsh-users/zsh-autosuggestions/issues/364
-	command true
+	autoload -Uz is-at-least
+	is-at-least 5.8 || command true
 
 	# Read the pid from the child process
 	read _ZSH_AUTOSUGGEST_CHILD_PID <&$_ZSH_AUTOSUGGEST_ASYNC_FD

--- a/zsh-autosuggestions.zsh
+++ b/zsh-autosuggestions.zsh
@@ -810,7 +810,8 @@ _zsh_autosuggest_async_request() {
 
 	# There's a weird bug here where ^C stops working unless we force a fork
 	# See https://github.com/zsh-users/zsh-autosuggestions/issues/364
-	command true
+	autoload -Uz is-at-least
+	is-at-least 5.8 || command true
 
 	# Read the pid from the child process
 	read _ZSH_AUTOSUGGEST_CHILD_PID <&$_ZSH_AUTOSUGGEST_ASYNC_FD


### PR DESCRIPTION
The bug is fixed in recent version of zsh, so the workaround is not needed anymore for fresh zsh:

https://github.com/zsh-users/zsh-autosuggestions/issues/364