### PR TITLE
zsh-autosuggestions.plugin.zsh: respect the standard

### DIFF
--- a/zsh-autosuggestions.plugin.zsh
+++ b/zsh-autosuggestions.plugin.zsh
@@ -1,1 +1,6 @@
-source ${0:A:h}/zsh-autosuggestions.zsh
+# According to the standard:
+# https://github.com/zdharma/Zsh-100-Commits-Club/blob/master/Zsh-Plugin-Standard.adoc
+0="${ZERO:-${${0:#$ZSH_ARGZERO}:-${(%):-%N}}}"
+0="${${(M)0:#/*}:-$PWD/$0}"
+
+source ${0:h}/zsh-autosuggestions.zsh


### PR DESCRIPTION
There is a need to handle `$0` correctly for all package managers. For example zpm define `ZERO` before plug-in is sourced. 

See: https://github.com/zdharma/Zsh-100-Commits-Club/blob/master/Zsh-Plugin-Standard.adoc#zero-handling