### PR TITLE
Ensure that we're using the builtin exec

### DIFF
--- a/src/async.zsh
+++ b/src/async.zsh
@@ -11,7 +11,7 @@ _zsh_autosuggest_async_request() {
 	# If we've got a pending request, cancel it
 	if [[ -n "$_ZSH_AUTOSUGGEST_ASYNC_FD" ]] && { true <&$_ZSH_AUTOSUGGEST_ASYNC_FD } 2>/dev/null; then
 		# Close the file descriptor and remove the handler
-		exec {_ZSH_AUTOSUGGEST_ASYNC_FD}<&-
+		builtin exec {_ZSH_AUTOSUGGEST_ASYNC_FD}<&-
 		zle -F $_ZSH_AUTOSUGGEST_ASYNC_FD
 
 		# We won't know the pid unless the user has zsh/system module installed
@@ -32,7 +32,7 @@ _zsh_autosuggest_async_request() {
 	fi
 
 	# Fork a process to fetch a suggestion and open a pipe to read from it
-	exec {_ZSH_AUTOSUGGEST_ASYNC_FD}< <(
+	builtin exec {_ZSH_AUTOSUGGEST_ASYNC_FD}< <(
 		# Tell parent process our pid
 		echo $sysparams[pid]
 
@@ -68,7 +68,7 @@ _zsh_autosuggest_async_response() {
 		zle autosuggest-suggest -- "$suggestion"
 
 		# Close the fd
-		exec {1}<&-
+		builtin exec {1}<&-
 	fi
 
 	# Always remove the handler

--- a/zsh-autosuggestions.zsh
+++ b/zsh-autosuggestions.zsh
@@ -766,7 +766,7 @@ _zsh_autosuggest_async_request() {
 	# If we've got a pending request, cancel it
 	if [[ -n "$_ZSH_AUTOSUGGEST_ASYNC_FD" ]] && { true <&$_ZSH_AUTOSUGGEST_ASYNC_FD } 2>/dev/null; then
 		# Close the file descriptor and remove the handler
-		exec {_ZSH_AUTOSUGGEST_ASYNC_FD}<&-
+		builtin exec {_ZSH_AUTOSUGGEST_ASYNC_FD}<&-
 		zle -F $_ZSH_AUTOSUGGEST_ASYNC_FD
 
 		# We won't know the pid unless the user has zsh/system module installed
@@ -787,7 +787,7 @@ _zsh_autosuggest_async_request() {
 	fi
 
 	# Fork a process to fetch a suggestion and open a pipe to read from it
-	exec {_ZSH_AUTOSUGGEST_ASYNC_FD}< <(
+	builtin exec {_ZSH_AUTOSUGGEST_ASYNC_FD}< <(
 		# Tell parent process our pid
 		echo $sysparams[pid]
 
@@ -823,7 +823,7 @@ _zsh_autosuggest_async_response() {
 		zle autosuggest-suggest -- "$suggestion"
 
 		# Close the fd
-		exec {1}<&-
+		builtin exec {1}<&-
 	fi
 
 	# Always remove the handler


### PR DESCRIPTION
I have a wrapper shell function for `exec()`  in my environment which started to behave unexpectedly after I updated `zsh-autosuggestions`.  I'm using the `unset ZSH_AUTOSUGGEST_USE_ASYNC` suggestion from the README as a workaround for now, but it'd be nice to enable async. This PR added the `builtin` precommand modifier to all occurances to `exec` in the code to ensure we use the builtin `exec` command _"rather than a shell function or external command"_.