### PR TITLE
Always reset file descriptor after consuming it

### DIFF
--- a/src/async.zsh
+++ b/src/async.zsh
@@ -73,4 +73,5 @@ _zsh_autosuggest_async_response() {
 
 	# Always remove the handler
 	zle -F "$1"
+	_ZSH_AUTOSUGGEST_ASYNC_FD=
 }

--- a/zsh-autosuggestions.zsh
+++ b/zsh-autosuggestions.zsh
@@ -828,6 +828,7 @@ _zsh_autosuggest_async_response() {
 
 	# Always remove the handler
 	zle -F "$1"
+	_ZSH_AUTOSUGGEST_ASYNC_FD=
 }
 
 #--------------------------------------------------------------------#


### PR DESCRIPTION
This prevents the request cancelling logic from closing an unrelated fd that happens to reuse the same number.

https://github.com/zsh-users/zsh-autosuggestions/blob/a411ef3e0992d4839f0732ebeb9823024afaaaa8/src/async.zsh#L12-L15