### PR TITLE
Fix 'bad math expression' bug

### DIFF
--- a/zsh-autosuggestions.zsh
+++ b/zsh-autosuggestions.zsh
@@ -253,7 +253,7 @@ _zsh_autosuggest_highlight_reset() {
 _zsh_autosuggest_highlight_apply() {
 	typeset -g _ZSH_AUTOSUGGEST_LAST_HIGHLIGHT
 
-	if (( $#POSTDISPLAY )); then
+	if (( ${#POSTDISPLAY} )); then
 		typeset -g _ZSH_AUTOSUGGEST_LAST_HIGHLIGHT="$#BUFFER $(($#BUFFER + $#POSTDISPLAY)) $ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE"
 		region_highlight+=("$_ZSH_AUTOSUGGEST_LAST_HIGHLIGHT")
 	else


### PR DESCRIPTION
The problem seems to be that when the POSTDISPLAY envvar is not set, `$#POSTDISPLAY` sometimes evaluates to `0POSTDISPLAY` instead of `0` as is desired.

Using curly braces to disambiguate should mitigate this issue. This should also be a low-risk change IMO.