### PR TITLE
Add Fig as an installation method to the README

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -2,6 +2,7 @@
 
 * [Packages](#packages)
 * [Antigen](#antigen)
+* [Fig](#fig)
 * [Oh My Zsh](#oh-my-zsh)
 * [Manual](#manual-git-clone)
 
@@ -27,6 +28,14 @@
     ```
 
 2. Start a new terminal session.
+
+## Fig
+
+[Fig](https://fig.io) adds apps, shortcuts, and autocomplete to your existing terminal.
+
+Install `zsh-autosuggestions` in just one click.
+
+<a href="https://fig.io/plugins/other/zsh-autosuggestions" target="_blank"><img src="https://fig.io/badges/install-with-fig.svg" /></a>
 
 ## Oh My Zsh
 


### PR DESCRIPTION
The [Fig Plugin Store](https://fig.io/plugins) supports 1-click install for 400+ shell plugins. We have over 100k users, thousands of whom manage their shell configuration with Fig.

Zsh Autosuggest is already listed in the store so we'd love to have it listed as a download method on your readme.

Thanks so much and please let me know if you have any questions!