### PR TITLE
Add history-beginning-search-forward-end and history-beginning-search-backward-end to ZSH_AUTOSUGGEST_CLEAR_WIDGETS

### DIFF
--- a/zsh-autosuggestions.zsh
+++ b/zsh-autosuggestions.zsh
@@ -54,6 +54,8 @@ typeset -g ZSH_AUTOSUGGEST_ORIGINAL_WIDGET_PREFIX=autosuggest-orig-
 		history-search-backward
 		history-beginning-search-forward
 		history-beginning-search-backward
+		history-beginning-search-forward-end
+		history-beginning-search-backward-end
 		history-substring-search-up
 		history-substring-search-down
 		up-line-or-beginning-search


### PR DESCRIPTION
Fixes issues #678. Based on modifications suggested here https://github.com/zsh-users/zsh-autosuggestions/issues/619#issuecomment-904193190. @artudytu @ericfreese