### PR TITLE
document requirements for widgets that call autosuggestion widgets (#716)

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Set `ZSH_AUTOSUGGEST_COMPLETION_IGNORE` to a [glob pattern](http://zsh.sourcefor
 
 ### Autosuggestion widgets
 
-This plugin provides a few widgets that you can use with `bindkey`:
+This plugin adds a few [zle widgets](http://zsh.sourceforge.net/Doc/Release/Zsh-Line-Editor.html#Zle-Widgets):
 
 1. `autosuggest-accept`: Accepts the current suggestion.
 2. `autosuggest-execute`: Accepts and executes the current suggestion.
@@ -115,12 +115,22 @@ This plugin provides a few widgets that you can use with `bindkey`:
 6. `autosuggest-enable`: Re-enables suggestions.
 7. `autosuggest-toggle`: Toggles between enabled/disabled suggestions.
 
-For example, this would bind <kbd>ctrl</kbd> + <kbd>space</kbd> to accept the current suggestion.
+You can bind any of these widgets to a keyboard shortcut with [`bindkey`](https://zsh.sourceforge.io/Doc/Release/Zsh-Line-Editor.html#Zle-Builtins). For example, the following command would bind <kbd>ctrl</kbd> + <kbd>space</kbd> to accept the current suggestion.
 
 ```sh
 bindkey '^ ' autosuggest-accept
 ```
 
+You can also call any of them directly with `zle`. For example, the following command would accept the current suggestion (for an explanation of `ZSH_AUTOSUGGEST_IGNORE_WIDGETS` see [Widget mapping](#widget-mapping), above).
+
+```sh
+my_widget() {
+  zle autosuggest-accept
+}
+typeset -ga ZSH_AUTOSUGGEST_IGNORE_WIDGETS
+ZSH_AUTOSUGGEST_IGNORE_WIDGETS+=( my_widget )
+zle -N my_widget
+```
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Widgets that modify the buffer and are not found in any of these arrays will fet
 
 **Note:** A widget shouldn't belong to more than one of the above arrays.
 
+**Note:** Any widget which calls one of the [autosuggestion widgets](#autosuggestion-widgets) must be added to `ZSH_AUTOSUGGEST_IGNORE_WIDGETS` before creating the new widget's keymap.
 
 ### Disabling suggestion for large buffers
 
@@ -102,7 +103,7 @@ Set `ZSH_AUTOSUGGEST_COMPLETION_IGNORE` to a [glob pattern](http://zsh.sourcefor
 **Note:** This only affects the `completion` suggestion strategy.
 
 
-### Key Bindings
+### Autosuggestion widgets
 
 This plugin provides a few widgets that you can use with `bindkey`:
 


### PR DESCRIPTION
I had time, so did this before hearing whether you're interested in the change with the expectation that you might simply close it.

&nbsp;

To call a zsh-autosuggestions widget from another custom widget, it is necessary to add the widget to `ZSH_AUTOSUGGEST_IGNORE_WIDGETS` before creating the custom widget keymap.

- #716
