### PR TITLE
do not ignore bound completion widgets

### DIFF
--- a/zsh-autosuggestions.zsh
+++ b/zsh-autosuggestions.zsh
@@ -3,7 +3,7 @@
 # v0.7.0
 # Copyright (c) 2013 Thiago de Arruda
 # Copyright (c) 2016-2021 Eric Freese
-# 
+#
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
 # files (the "Software"), to deal in the Software without
@@ -12,10 +12,10 @@
 # copies of the Software, and to permit persons to whom the
 # Software is furnished to do so, subject to the following
 # conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be
 # included in all copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 # EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
 # OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -195,10 +195,15 @@ _zsh_autosuggest_bind_widgets() {
 
  	local widget
 	local ignore_widgets
+	local bcompwidgets
+
+	# don't want to ignore bound completion widgets
+	# user can manually override this using ZSH_AUTOSUGGEST_IGNORE_WIDGETS
+	bcompwidgets=${(j:|:)${(M)${${(f)"$(builtin bindkey)"}##*[[:space:]]##}:#_*}}
 
 	ignore_widgets=(
 		.\*
-		_\*
+		_^\(${bcompwidgets}\)
 		${_ZSH_AUTOSUGGEST_BUILTIN_ACTIONS/#/autosuggest-}
 		$ZSH_AUTOSUGGEST_ORIGINAL_WIDGET_PREFIX\*
 		$ZSH_AUTOSUGGEST_IGNORE_WIDGETS


### PR DESCRIPTION
Hi, 

I have some completion widgets, which I use from time to time bound in my config. Notably:
	  _history-complete-older
	  _history-complete-newer
	  _history_complete_word

I noticed that when I use them they insert the word from history, but also lead to the suggestion line beeing completed till the end after the inserted word. This kind of messes up what I was trying to do in the first place. So I wrote a small fix which would only add the NON-bound completion widgets (beginning with _) to the ignore_widgets array.

Seems to work nicely, so maybe you could have a look.

Thanks

BR
s.



