### PR TITLE
Don't discard $WIDGETSTYLE

### DIFF
--- a/zsh-autosuggestions.zsh
+++ b/zsh-autosuggestions.zsh
@@ -231,7 +231,7 @@ _zsh_autosuggest_invoke_original_widget() {
 	shift
 
 	if (( ${+widgets[$original_widget_name]} )); then
-		zle $original_widget_name -- $@
+		zle $original_widget_name -w -- $@
 	fi
 }
 


### PR DESCRIPTION
Calling a completion widget without passing the -w flag causes $WIDGETSTYLE to be unset. This breaks logic in _oldlist, _list_files and some plugins.