### PR TITLE
Allow wrapping widgets whose name start with _ (underscore)

### DIFF
--- a/src/bind.zsh
+++ b/src/bind.zsh
@@ -68,7 +68,7 @@ _zsh_autosuggest_bind_widgets() {
 
 	ignore_widgets=(
 		.\*
-		_\*
+		_zsh_autosuggest_\*
 		${_ZSH_AUTOSUGGEST_BUILTIN_ACTIONS/#/autosuggest-}
 		$ZSH_AUTOSUGGEST_ORIGINAL_WIDGET_PREFIX\*
 		$ZSH_AUTOSUGGEST_IGNORE_WIDGETS

--- a/zsh-autosuggestions.zsh
+++ b/zsh-autosuggestions.zsh
@@ -198,7 +198,7 @@ _zsh_autosuggest_bind_widgets() {
 
 	ignore_widgets=(
 		.\*
-		_\*
+		_zsh_autosuggest_\*
 		${_ZSH_AUTOSUGGEST_BUILTIN_ACTIONS/#/autosuggest-}
 		$ZSH_AUTOSUGGEST_ORIGINAL_WIDGET_PREFIX\*
 		$ZSH_AUTOSUGGEST_IGNORE_WIDGETS


### PR DESCRIPTION
Hi folks,

When creating a zle widget whose name starts with `_`, it is ignored by zsh-autosuggestions, leading to various situations where the suggestion should be refreshed, but isn't.

Typically, other plugins often create such widgets, making them incompatible with zsh-autosuggestions.

This PR changes this.

Preliminary testing seems to indicate everything works fine on my machine, and before going through more extensive testing and/or writing tests, I wanted to ask if there's a specific reason to forbid wrapping such widgets.

It _looks like_ the current presence check is not a mistake, but a voluntary design, but I can't understand why. As far as I can tell, the only reason to ban such widget names, is to prevent wrapping an already-wrapped widget.
Which the proposed change still does.


https://github.com/zsh-users/zsh-autosuggestions/issues/737 is a manifestation of this issue, and provides a nice minimal reproducing example (although the problem is bigger than stated there, as it affects all types of widget wrapping)


If we go through with this change, it would likely require a `0.8.0` tag, as suddenly starting to wrap previously-unwrapped widgets may break unexpectedly on specific edge cases. It is however possible for users with such a setup to reproduce the current behavior with `ZSH_AUTOSUGGEST_IGNORE_WIDGETS`, so, it's not a blocking change.

Please let me know if I've missed the rationale behind the current design !