### PR TITLE
Fix `widget name '....' is protected`

### DIFF
--- a/zsh-autosuggestions.zsh
+++ b/zsh-autosuggestions.zsh
@@ -186,7 +186,7 @@ _zsh_autosuggest_bind_widget() {
 	}"
 
 	# Create the bound widget
-	zle -N -- $widget _zsh_autosuggest_bound_${bind_count}_$widget
+	[[ "$widget" = .* ]] || zle -N -- $widget _zsh_autosuggest_bound_${bind_count}_$widget
 }
 
 # Map all configured widgets to the right autosuggest widgets


### PR DESCRIPTION
closes #653