### PR TITLE
Update INSTALL link for Mac OS - homebrew moved under z/

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -15,7 +15,7 @@
 | Arch Linux / Manjaro / Antergos / Hyperbola | [zsh-autosuggestions](https://www.archlinux.org/packages/zsh-autosuggestions), [zsh-autosuggestions-git](https://aur.archlinux.org/packages/zsh-autosuggestions-git) |
 | NixOS | [zsh-autosuggestions](https://github.com/NixOS/nixpkgs/blob/master/pkgs/shells/zsh/zsh-autosuggestions/default.nix) |
 | Void Linux | [zsh-autosuggestions](https://github.com/void-linux/void-packages/blob/master/srcpkgs/zsh-autosuggestions/template) |
-| Mac OS | [homebrew](https://github.com/Homebrew/homebrew-core/blob/master/Formula/zsh-autosuggestions.rb)  |
+| Mac OS | [homebrew](https://github.com/Homebrew/homebrew-core/blob/master/Formula/z/zsh-autosuggestions.rb)  |
 | NetBSD | [pkgsrc](http://ftp.netbsd.org/pub/pkgsrc/current/pkgsrc/shells/zsh-autosuggestions/README.html)  |
 
 ## Antigen


### PR DESCRIPTION
See https://github.com/Homebrew/homebrew-core/commit/442f9cc511ce6dfe75b96b2c83749d90dde914d2

Also, it might be nice to include `brew install zsh-autosuggestions` there as the package definition doesn't help someone with how to actually _install_ it unless they know how homebrew works. Also, if you aren't aware of homebrew's `Caveats`, it might be easy to miss

```
==> Caveats
To activate the autosuggestions, add the following at the end of your .zshrc:

  source /opt/homebrew/share/zsh-autosuggestions/zsh-autosuggestions.zsh

You will also need to restart your terminal for this change to take effect.
```

So I would also suggest adding that to your install documentation page.