### PR TITLE
Stop requiring function_argzero

### DIFF
--- a/zsh-autosuggestions.plugin.zsh
+++ b/zsh-autosuggestions.plugin.zsh
@@ -1,1 +1,2 @@
+0=${(%):-%N}
 source ${0:A:h}/zsh-autosuggestions.zsh


### PR DESCRIPTION
This commit is based on [zsh-syntax-highlighting's similar commit][1].

Also, motivated from PR #640.

[1]: https://github.com/zsh-users/zsh-syntax-highlighting/commit/750aebc553f2f4149055ef4cb9d7641f5df6d3ea