### PR TITLE
Implements two of the skipped unit tests

### DIFF
--- a/spec/integrations/zle_input_stack_spec.rb
+++ b/spec/integrations/zle_input_stack_spec.rb
@@ -9,10 +9,17 @@ describe 'using `zle -U`' do
 
   let(:options) { ['unset ZSH_AUTOSUGGEST_USE_ASYNC', 'ZSH_AUTOSUGGEST_STRATEGY=test'] }
 
-  # TODO: This is only possible with the $KEYS_QUEUED_COUNT widget parameter, coming soon...
-  xit 'does not fetch a suggestion for every inserted character' do
+  # This is only possible with the $KEYS_QUEUED_COUNT widget parameter
+  it 'does not fetch a suggestion for every inserted character' do
     session.send_keys('C-b')
-    wait_for { session.content }.to eq('echo hello')
+
+    # Check if zsh >= 5.4
+    version_arr = ENV['TEST_ZSH_BIN'].split('zsh-')[1].split('.')
+    if version_arr[0].to_i >= 6 || (version_arr[0].to_i == 5 && version_arr[1].to_i >= 4)
+      wait_for { session.content }.to eq('echo hello')
+    else
+      skip "depends on KEYS_QUEUED_COUNT which requires zsh 5.4 or above"
+    end
   end
 
   it 'shows a suggestion when the widget completes' do

--- a/spec/options/buffer_max_size_spec.rb
+++ b/spec/options/buffer_max_size_spec.rb
@@ -25,6 +25,10 @@ describe 'a suggestion' do
       wait_for { session.content }.to eq(long_command)
     end
 
-    it 'is not provided when the buffer is longer than the specified length'
+    it 'is not provided when the buffer is longer than the specified length' do
+      session.send_string(long_command[0...(buffer_max_size + 1)])
+      sleep 1
+      expect(session.content).to eq(long_command[0...(buffer_max_size + 1)])
+    end
   end
 end


### PR DESCRIPTION
This implements two unit tests that were being skipped:

1. **options/buffer_max_size_spec.rb** - _a suggestion when ZSH_AUTOSUGGEST_BUFFER_MAX_SIZE is specified is not provided when the buffer is longer than the specified length_

2. **integrations/zle_input_stack_spec** - _using `zle -U` does not fetch a suggestion for every inserted character_
(Note: this still skips if zsh < 5.4)