### PR TITLE
fix(install_test_zsh.sh): fetch latest config.{guess,sub} files

### DIFF
--- a/install_test_zsh.sh
+++ b/install_test_zsh.sh
@@ -6,6 +6,8 @@ mkdir zsh-build
 cd zsh-build
 
 curl -L https://api.github.com/repos/zsh-users/zsh/tarball/zsh-$TEST_ZSH_VERSION | tar xz --strip=1
+curl -o config.guess 'https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=refs/heads/master'
+curl -o config.sub 'https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD'
 
 ./Util/preconfig
 ./configure --enable-pcre \


### PR DESCRIPTION
Resolves error when ran on arm64/aarch64 systems (i.e., Arm64 MacOS & Docker).

## Before

<img width="1241" alt="before" src="https://github.com/user-attachments/assets/4d00a138-99d8-4c04-949a-6fb337ab8755">

---

<img width="1728" alt="Screenshot 2024-09-02 at 12 59 55" src="https://github.com/user-attachments/assets/033657a5-531d-4469-9c93-19f60dd12776">

## After

<img width="1728" alt="Screenshot 2024-09-02 at 12 36 09" src="https://github.com/user-attachments/assets/5142a07a-a994-47bb-9f86-1ad4b381faf1">

---

<img width="1728" alt="Screenshot 2024-09-02 at 12 36 16" src="https://github.com/user-attachments/assets/23589a56-d1a8-4a8b-ae35-89b7eca857bf">