### PR TITLE
Add possibility to replace the entire buffer from suggestion strategies

### DIFF
--- a/src/async.zsh
+++ b/src/async.zsh
@@ -38,8 +38,10 @@ _zsh_autosuggest_async_request() {
 
 		# Fetch and print the suggestion
 		local suggestion
+		local new_buffer
 		_zsh_autosuggest_fetch_suggestion "$1"
-		echo -nE "$suggestion"
+		echo -E $suggestion
+		echo -E $new_buffer
 	)
 
 	# There's a weird bug here where ^C stops working unless we force a fork
@@ -61,11 +63,13 @@ _zsh_autosuggest_async_response() {
 	emulate -L zsh
 
 	local suggestion
+	local new_buffer
 
 	if [[ -z "$2" || "$2" == "hup" ]]; then
 		# Read everything from the fd and give it as a suggestion
-		IFS='' read -rd '' -u $1 suggestion
-		zle autosuggest-suggest -- "$suggestion"
+		read -r -u $1 suggestion
+		read -r -u $1 new_buffer
+		zle autosuggest-suggest -- "$suggestion" "$new_buffer"
 
 		# Close the fd
 		builtin exec {1}<&-

--- a/src/fetch.zsh
+++ b/src/fetch.zsh
@@ -19,7 +19,10 @@ _zsh_autosuggest_fetch_suggestion() {
 		_zsh_autosuggest_strategy_$strategy "$1"
 
 		# Ensure the suggestion matches the prefix
-		[[ "$suggestion" != "$1"* ]] && unset suggestion
+		if [[ "$suggestion" != "$1"* ]]; then
+			unset suggestion
+			unset new_buffer
+		fi
 
 		# Break once we've found a valid suggestion
 		[[ -n "$suggestion" ]] && break


### PR DESCRIPTION
This PR adds the possibility to not only append text on suggestion but also in specific cases replace the entire buffer.
Use case is described in https://github.com/daanvdk/zsh-autosuggest-abbr-history.