### PR TITLE
allow running with set -u (no unset var)

### DIFF
--- a/zsh-autosuggestions.zsh
+++ b/zsh-autosuggestions.zsh
@@ -255,7 +255,7 @@ _zsh_autosuggest_highlight_reset() {
 _zsh_autosuggest_highlight_apply() {
 	typeset -g _ZSH_AUTOSUGGEST_LAST_HIGHLIGHT
 
-	if (( $#POSTDISPLAY )); then
+	if (( ${#POSTDISPLAY-} )); then
 		typeset -g _ZSH_AUTOSUGGEST_LAST_HIGHLIGHT="$#BUFFER $(($#BUFFER + $#POSTDISPLAY)) $ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE"
 		region_highlight+=("$_ZSH_AUTOSUGGEST_LAST_HIGHLIGHT")
 	else


### PR DESCRIPTION
I have been using this for a while.
It makes me feel safer by turning on set -u by default, which abort on unset var

This line seems to be the only one tripping set -u so this is a very simple change.