### PR TITLE
Update homebrew install link to point to homebrew website.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -17,7 +17,7 @@
 | Arch Linux / Manjaro / Antergos / Hyperbola | [zsh-autosuggestions](https://www.archlinux.org/packages/zsh-autosuggestions), [zsh-autosuggestions-git](https://aur.archlinux.org/packages/zsh-autosuggestions-git) |
 | NixOS | [zsh-autosuggestions](https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/zs/zsh-autosuggestions/package.nix) |
 | Void Linux | [zsh-autosuggestions](https://github.com/void-linux/void-packages/blob/master/srcpkgs/zsh-autosuggestions/template) |
-| Mac OS | [homebrew](https://github.com/Homebrew/homebrew-core/blob/master/Formula/z/zsh-autosuggestions.rb)  |
+| Mac OS | [homebrew](https://formulae.brew.sh/formula/zsh-autosuggestions)  |
 | NetBSD | [pkgsrc](http://ftp.netbsd.org/pub/pkgsrc/current/pkgsrc/shells/zsh-autosuggestions/README.html)  |
 
 ## Antigen


### PR DESCRIPTION
 the [file in the homebrew repo](https://github.com/Homebrew/homebrew-core/blob/master/Formula/z/zsh-autosuggestions.rb) does not provide a clear instructions to install
 
 https://formulae.brew.sh/formula/zsh-autosuggestions links to the ruby file so I think this link is more helpful. 

[brew.sh](https://brew.sh) is the offlical website on the [homebrew-core repo](https://github.com/Homebrew/homebrew-core/) page