### PR TITLE
fix completion strategy blocking fallback to history

### DIFF
--- a/src/strategies/completion.zsh
+++ b/src/strategies/completion.zsh
@@ -130,6 +130,9 @@ _zsh_autosuggest_strategy_completion() {
 		# the second null byte, so trim those off the end.
 		# See http://www.zsh.org/mla/workers/2015/msg03290.html
 		suggestion="${${(@0)line}[2]}"
+
+		# If the suggestion is the same as the input, treat it as no suggestion
+		[[ "$suggestion" == "$1" ]] && unset suggestion
 	} always {
 		# Destroy the pty
 		zpty -d $ZSH_AUTOSUGGEST_COMPLETIONS_PTY_NAME

--- a/zsh-autosuggestions.zsh
+++ b/zsh-autosuggestions.zsh
@@ -3,7 +3,7 @@
 # v0.7.1
 # Copyright (c) 2013 Thiago de Arruda
 # Copyright (c) 2016-2021 Eric Freese
-# 
+#
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
 # files (the "Software"), to deal in the Software without
@@ -12,10 +12,10 @@
 # copies of the Software, and to permit persons to whom the
 # Software is furnished to do so, subject to the following
 # conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be
 # included in all copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 # EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
 # OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -625,6 +625,9 @@ _zsh_autosuggest_strategy_completion() {
 		# the second null byte, so trim those off the end.
 		# See http://www.zsh.org/mla/workers/2015/msg03290.html
 		suggestion="${${(@0)line}[2]}"
+
+		# If the suggestion is the same as the input, treat it as no suggestion
+		[[ "$suggestion" == "$1" ]] && unset suggestion
 	} always {
 		# Destroy the pty
 		zpty -d $ZSH_AUTOSUGGEST_COMPLETIONS_PTY_NAME


### PR DESCRIPTION
When using `ZSH_AUTOSUGGEST_STRATEGY=(completion history)`, the completion strategy would prevent fallback to history even when no completions were found. The completion strategy returned the original input as the suggestion when no completions existed, causing the strategy loop to exit early instead of trying the next strategy. 

I added a check to unset suggestion if it equals the input. Now the history strategy is properly tried when completion finds nothing.